### PR TITLE
Always require activation for requestStorageAccess (fixes #36)

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -195,6 +195,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 1. Let |p| be [=a new promise=].
 1. [=Enqueue the following steps=] on the [=permission task source=]:
+    1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p|.
     1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
     1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
     1. If |key| is failure, [=reject=] |p|.
@@ -207,7 +208,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L146 --> <!-- Gecko's Document.cpp#l15604 --> <!-- Gecko's Document.cpp#l15657 -->
     1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L152 --> <!-- Gecko's Document.cpp#l15667 -->
     1. If |doc|'s [=Document/browsing context=]'s [=parent browsing context=] is not a [=top-level browsing context=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L158 --> <!-- Gecko's Document.cpp#l15673 -->
-    1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L163 --> <!-- Gecko's Document.cpp#l15680 -->
     1. [=Determine the storage access policy=] with |key|, |doc|, and |p|. <!-- WebKit's DocumentStorageAccess.cpp#L177 --> <!-- Gecko's Document.cpp#l15685 -->
     1. Set |flag set|'s [=has storage access flag=].
     1. [=Save the storage access flag set=] for |key| in |map|.


### PR DESCRIPTION
This also removes outdated references to the WebKit and Gecko code,
both of which now also need to change to adhere to the new spec.