### PR TITLE
Fix async steps in hasStorageAccess and requestStorageAccess.

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -182,8 +182,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Run these steps [=in parallel=]:
     1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
     1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-    1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with false and abort these steps.
-    1. If |flag set|'s [=has storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with true and abort these steps.
+    1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with false, and abort these steps.
+    1. If |flag set|'s [=has storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with true, and abort these steps.
     1. Let |hasAccess| be [=a new promise=].
     1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with the result of |hasAccess|.
@@ -247,15 +247,15 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for [=parti
 
     Note: These [=implementation-defined=] set of steps might result in |flag set|'s [=has storage access flag=] and [=was expressly denied storage access flag=] changing, since the User Agent could have relevant out-of-band information (e.g. a user preference that changed) that this specification is unaware of.
 1. Let |global| be |doc|'s [=relevant global object=].
-1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| and return.
-1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| and return.
+1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p|, and return.
 1. Ask the user if they would like to grant |key|'s [=partitioned storage key/embedded site=] access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |key|'s [=partitioned storage key/top-level site=], and wait for an answer. Let |expressly granted| and |expressly denied| (both [=booleans=]) be the result.
 
     Note: While |expressly granted| and |expressly denied| cannot both be true, they could both be false in User Agents which allow users to dismiss the prompt without choosing to allow or deny the request. (Such a dismissal is interpreted in this algorithm as a denial.)
 1. If |expressly granted| is true, run these steps:
     1. Unset |flag set|'s [=was expressly denied storage access flag=].
     1. [=Save the storage access flag set=] for |key| in |map|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| and return.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. Unset |flag set|'s [=has storage access flag=].
 1. If |expressly denied| is true, run these steps:
     1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -172,17 +172,21 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15512 -->
 
 1. Let |p| be [=a new promise=].
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. If |key| is failure, then [=/resolve=] |p| with false and return |p|.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=/resolve=] |p| with false and return |p|. <!-- WebKit's DocumentStorageAccess.cpp#L85 -->
-1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- WebKit's DocumentStorageAccess.cpp#L90 --> <!-- Gecko's Document.cpp#l15526 -->
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|. <!-- WebKit's DocumentStorageAccess.cpp#L95 --> <!-- Gecko's Document.cpp#l15531 -->
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. Let |topDoc| be the [=active document=] of |doc|'s [=Document/browsing context=]'s [=top-level browsing context=].
-1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] |p| with true and return |p|. <!-- WebKit's DocumentStorageAccess.cpp#L102 --> <!-- Gecko's Document.cpp#l15541 -->
+1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] |p| with true and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. [=/Resolve=] |p| with the result of running [=determine if a site has storage access=] with |key| and |doc|. <!-- WebKit's DocumentStorageAccess.cpp#L115 --> <!-- Gecko's Document.cpp#l15548 -->
+1. If |key| is failure, [=resolve=] |p| with false and return |p|.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Run these steps [=in parallel=]:
+    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+    1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with false and abort these steps.
+    1. If |flag set|'s [=has storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with true and abort these steps.
+    1. Let |hasAccess| be [=a new promise=].
+    1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with the result of |hasAccess|.
 1. Return |p|.
 
 ISSUE: Shouldn't step 7 be [=same site=]?
@@ -194,24 +198,27 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15629 -->
 
 1. Let |p| be [=a new promise=].
-1. [=Enqueue the following steps=] on the [=permission task source=]:
-    1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p|.
-    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-    1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-    1. If |key| is failure, [=reject=] |p|.
-    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-    1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=reject=] |p|.
-    1. If |flag set|'s [=has storage access flag=] is set, [=/resolve=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L128 --> <!-- Gecko's Document.cpp#l15604 -->
-    1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L133 --> <!-- Gecko's Document.cpp#l15618 -->
-    1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L138 --> <!-- Gecko's Document.cpp#l15632 -->
-    1. Let |topDoc| be the [=active document=] of |doc|'s [=Document/browsing context=]'s [=top-level browsing context=].
-    1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L146 --> <!-- Gecko's Document.cpp#l15604 --> <!-- Gecko's Document.cpp#l15657 -->
-    1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L152 --> <!-- Gecko's Document.cpp#l15667 -->
-    1. If |doc|'s [=Document/browsing context=]'s [=parent browsing context=] is not a [=top-level browsing context=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L158 --> <!-- Gecko's Document.cpp#l15673 -->
-    1. [=Determine the storage access policy=] with |key|, |doc|, and |p|. <!-- WebKit's DocumentStorageAccess.cpp#L177 --> <!-- Gecko's Document.cpp#l15685 -->
-    1. Set |flag set|'s [=has storage access flag=].
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
+1. If |doc|'s [=Document/browsing context=]'s [=parent browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
+1. Let |topDoc| be the [=active document=] of |doc|'s [=Document/browsing context=]'s [=top-level browsing context=].
+1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
+1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] and return |p|.
+1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
+1. If |key| is failure, [=reject=] and return |p|.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=reject=] and return |p|.
+1. If |flag set|'s [=has storage access flag=] is set, [=/resolve=] and return |p|.
+1. Otherwise, run these steps [=in parallel=]:
+    1. Let |hasAccess| be [=a new promise=].
+    1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to
+        1. Set |flag set|'s [=has storage access flag=].
+        1. Resolve or reject |p| based on the result of |hasAccess|.
     1. [=Save the storage access flag set=] for |key| in |map|.
-    1. [=/Resolve=] |p|. <!-- Gecko's Document.cpp#l15805 -->
 1. Return |p|.
 
 ISSUE: Shouldn't step 3.7 be [=same site=]?
@@ -239,21 +246,22 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for [=parti
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded site=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
 
     Note: These [=implementation-defined=] set of steps might result in |flag set|'s [=has storage access flag=] and [=was expressly denied storage access flag=] changing, since the User Agent could have relevant out-of-band information (e.g. a user preference that changed) that this specification is unaware of.
-1. If |implicitly granted| is true, [=/resolve=] |p| and return.
-1. If |implicitly denied| is true, [=/reject=] |p| and return.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| and return.
+1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| and return.
 1. Ask the user if they would like to grant |key|'s [=partitioned storage key/embedded site=] access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |key|'s [=partitioned storage key/top-level site=], and wait for an answer. Let |expressly granted| and |expressly denied| (both [=booleans=]) be the result.
 
     Note: While |expressly granted| and |expressly denied| cannot both be true, they could both be false in User Agents which allow users to dismiss the prompt without choosing to allow or deny the request. (Such a dismissal is interpreted in this algorithm as a denial.)
 1. If |expressly granted| is true, run these steps:
     1. Unset |flag set|'s [=was expressly denied storage access flag=].
     1. [=Save the storage access flag set=] for |key| in |map|.
-    1. [=/Resolve=] |p| and return. <!-- WebKit's DocumentStorageAccess.cpp#L191 -->
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| and return.
 1. Unset |flag set|'s [=has storage access flag=].
 1. If |expressly denied| is true, run these steps:
-    1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it. <!-- WebKit's DocumentStorageAccess.cpp#L181 -->
+    1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
     1. Set |flag set|'s [=was expressly denied storage access flag=].
 1. [=Save the storage access flag set=] for |key| in |map|.
-1. [=/Reject=] |p| and return. <!-- WebKit's DocumentStorageAccess.cpp#L194 --> <!-- Gecko's Document.cpp#l15805 -->
+1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p|.
 
 ISSUE: [since this is UA-defined, does it make sense to follow-up separately with a user prompt?](https://github.com/privacycg/storage-access/pull/24#discussion_r408784492)
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -195,6 +195,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 1. Let |p| be [=a new promise=].
 1. [=Enqueue the following steps=] on the [=permission task source=]:
+    1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p|.
     1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
     1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
     1. If |key| is failure, [=reject=] |p|.
@@ -207,7 +208,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. If |doc| is [=same origin=] with |topDoc|, [=/resolve=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L146 --> <!-- Gecko's Document.cpp#l15604 --> <!-- Gecko's Document.cpp#l15657 -->
     1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L152 --> <!-- Gecko's Document.cpp#l15667 -->
     1. If |doc|'s [=Document/browsing context=]'s [=parent browsing context=] is not a [=top-level browsing context=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L158 --> <!-- Gecko's Document.cpp#l15673 -->
-    1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p|. <!-- WebKit's DocumentStorageAccess.cpp#L163 --> <!-- Gecko's Document.cpp#l15680 -->
     1. [=Determine the storage access policy=] with |key|, |doc|, and |p|. <!-- WebKit's DocumentStorageAccess.cpp#L177 --> <!-- Gecko's Document.cpp#l15685 -->
     1. Set |flag set|'s [=has storage access flag=].
     1. [=Save the storage access flag set=] for |key| in |map|.


### PR DESCRIPTION
This includes another commit because it is based on #68

Fixes #50, #69

This is based on some of Anne's feedback around how we run async steps
in parallel and queue tasks for resolving promises instead of what we
were doing before.

This also moves a bunch of things that probably don't need to happen
in parallel (and don't happen in parallel in at least Gecko and WebKit)
out of the async steps.

