### PR TITLE
Permissions Policy Integration (formalize nested iframe support)

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -104,8 +104,6 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
-ISSUE(10): If we let nested <{iframe}>s use this API, we may have to revisit these definitions.
-
 <h3 id="ua-state">User Agent state related to storage access</h3>
 
 A <dfn>storage access map</dfn> is a [=map=] whose keys are [=partitioned storage keys=] and whose values are [=storage access flag sets=].
@@ -202,7 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
-1. If |doc|'s [=Document/browsing context=]'s [=parent browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
+1. If |doc|'s [=relevant settings object=] is not [=allowed to use=] the `"request-storage-access"` permission, [=reject=] and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
@@ -224,8 +222,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Return |p|.
 
 ISSUE: Shouldn't step 3.7 be [=same site=]?
-
-ISSUE(10): Remove step 3.9 if we determine that nested <{iframe}>s should be able to request storage access.
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 
@@ -301,7 +297,11 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 <li>The [=sandbox storage access by user activation flag=], unless <var ignore>tokens</var> contains the <dfn export attr-value for=iframe/sandbox>allow-storage-access-by-user-activation</dfn> keyword.
 </ul>
 
-ISSUE(12): What about Feature Policy?
+<h2 id="permissions-policy-integration">Permissions Policy Integration</h3>
+
+The Storage Access API defines a [=policy-controlled feature=] identified by the string `"request-storage-access"`. Its [=default allowlist=] is `"*"`.
+
+    Note: A {{Document}}’s [=Document/permissions policy=] determines whether any content in that document is allowed to request storage access using {{Document/requestStorageAccess()}}. If disabled in any document, calling {{Document/requestStorageAccess()}} in that document will reject.
 
 <h2 id="privacy">Privacy considerations</h2>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -200,7 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
-1. If |doc|'s [=relevant settings object=] is not [=allowed to use=] the `"request-storage-access"` permission, [=reject=] and return |p|.
+1. If |doc| is not [=allowed to use=] the `"request-storage-access"` permission, [=reject=] and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -297,7 +297,7 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 <li>The [=sandbox storage access by user activation flag=], unless <var ignore>tokens</var> contains the <dfn export attr-value for=iframe/sandbox>allow-storage-access-by-user-activation</dfn> keyword.
 </ul>
 
-<h2 id="permissions-policy-integration">Permissions Policy Integration</h3>
+<h2 id="permissions-policy-integration">Permissions Policy Integration</h2>
 
 The Storage Access API defines a [=policy-controlled feature=] identified by the string `"request-storage-access"`. Its [=default allowlist=] is `"*"`.
 


### PR DESCRIPTION
This is a first stab at integrating permissions policy and support nested iframes in the spec, see #10 and #12 . A few notes:

* I'm happy to bikeshed on the permission name (`"request-storage-access"`). It's important to note that this policy only controls *requesting* storage access, it does not tell user agents with persistent/passive storage (see #2) how to behave if an `allow=none` attribute was added after an iframe received storage access.
* We're now using the `"*"` default allowlist which @annevk [intended to deprecate](https://github.com/w3c/webappsec-permissions-policy/issues/381). We went back and fort on this but ultimately `"*"` captures the reality of current implementations best, especially considering that WebKit does not have PP support (and thus implictly default to `"*"`) for the time being. If we had started from scratch on this then maybe `"self"` would have been the best option, but personally I don't see that happening without WebKit support. Let me know if anyone disagrees.
* If I understand correctly this would also allow sites to use the PP header to globally reject all rSA calls, which is fixing #56 