### PR TITLE
Forward Declared API Addition

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -156,7 +156,7 @@ A <dfn>storage access flag set</dfn> is a set of zero or more of the following f
 :: When set, this flag indicates |embedded site| has access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
 : The <dfn for="storage access flag set" id=was-expressly-denied-storage-access-flag>was expressly denied storage access flag</dfn>
 :: When set, this flag indicates that the user expressly denied |embedded site| access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
-: The <dfn for="has allow request storage access flag sett" id=has-allow-request-storage-access-flag>has allow request storage access flag</dfn>
+: The <dfn for="has allow request storage access flag set" id=has-allow-request-storage-access-flag>has allow request storage access flag</dfn>
 :: When set, this flag indicates |top-level site| is allowing |embedded site| to request access to its [=unpartitioned data=] on |top-level site| from the |embedded site| [=first-party-site context=].
 
 To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partitioned storage key=] |key| from a [=/storage access map=] |map|, run the following steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -99,13 +99,14 @@ Script in the <{iframe}> can call |doc|`.`{{Document/hasStorageAccess()}} to det
 </div>
 
 This specification defines a method for a {{Document}} to request access to its [=unpartitioned data=] when later used in a [=third party context=] whose active Document's origin is same-site with a specified site ({{Document/requestStorageAccessUnderSite()}}).
-This specification additionally defines a method for a Document to allow such requests to succeed with arguments that are same-site to its origin in a [=browsing context=] whose active Document's origin is same-site with a specified site ({{Document/allowStorageAccessRequestOnSite()}}).
+This specification additionally defines a method for a Document to allow such requests to succeed with arguments that are same-site to its origin in a [=/browsing context=] whose active Document's origin is same-site with a specified site ({{Document/allowStorageAccessRequestOnSite()}}).
 
 <div class=example>
 
 Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and navigates to `https://identity.example` when the returned promise resolves.
 
-Once navigated, Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the [=browsing context=] navigates, returning Alex to `https://site.example`.
+Once navigated, Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`.
+Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the [=/browsing context=] navigates, returning Alex to `https://site.example`.
 
 When Alex returns to `https://site.example` requests to `https://identity.example` will bear the cookie set in the previous [=window=].
 
@@ -244,11 +245,11 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>al
 
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
-1. Let |parsedURI| be the result of parsing |embeddedURI|.
+1. Let |parsedURI| be the result of running the [=URL parser=] on <var ignore>embeddedURI</var>.
 1. If |parsedURI| is failure, [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
-1. Let |parsedOrigin| be the result of obtaining the origin of |parsedURI|.
+1. Let |parsedOrigin| be the |parsedURI|'s origin.
 1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
@@ -263,17 +264,15 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>al
     1. [=Resolve=] p.
 1. Return |p|.
 
-ISSUE: Deserialization of site is not well defined
-
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString topLevelURI)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
-1. Let |parsedURI| be the result of parsing |embeddedURI|.
+1. Let |parsedURI| be the result of running the [=URL parser=] on <var ignore>topLevelURI</var>.
 1. If |parsedURI| is failure, [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
-1. Let |parsedOrigin| be the result of obtaining the origin of |parsedURI|.
+1. Let |parsedOrigin| be the |parsedURI|'s origin.
 1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
@@ -299,8 +298,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
         1. Resolve |p|.
     1. [=Save the storage access flag set=] for |key| in |map|.
 1. Return |p|.
-
-
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -176,7 +176,7 @@ To <dfn type="abstract-op">save the storage access flag set</dfn> for a [=partit
 partial interface Document {
   Promise&lt;boolean> hasStorageAccess();
   Promise&lt;undefined> requestStorageAccess();
-  Promise&lt;undefined> allowRequestStorageAccessOnSite(DOMString serializedSite);
+  Promise&lt;undefined> allowStorageAccessRequestOnSite(DOMString serializedSite);
   Promise&lt;undefined> requestStorageAccessUnderSite(DOMString serializedSite);
 };
 </pre>
@@ -254,7 +254,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>al
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. Set |flag set|’s [=has allow request storage access flag=].
 1. [=Save the storage access flag set=] for |key| in |map|.
-1. Wait for a call to [{{Document/requestStorageAccessUnderSite()}}] on a {{Document}} with [=site=] |thirdPartySite|.
+1. Wait for a call to {{Document/requestStorageAccessUnderSite()}} on a {{Document}} with [=site=] |thirdPartySite|.
 1. Unset |flag set|’s [=has allow request storage access flag=].
 1. [=Resolve=] and return |p|.
 
@@ -275,7 +275,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|’s [=was expressly denied storage access flag=] is set, 
-    1. Notify all waiting tasks of [{{Document/allowRequestStorageAccessOnSite()}}] with argument corresponding |doc|'s [=site=].
+    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
     1. [=resolve=] |p|
     1. return |p|.
 1. If |flag set|’s [=has storage access flag=] is set, 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -104,9 +104,9 @@ This specification also defines a method for a [=site=] to request access to its
 
 Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and opens a new [=window=] for `https://identity.example`.
 
-In the new [=window=], Alex selects the account to log in with. In response, `https://identity.example` sets a [=cookie=], which by virtue of its [=first party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the `https://identity.example` [=window=] closes itself, returning Alex to `https://site.example`.
+In the new [=window=], Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the `https://identity.example` [=window=] closes itself, returning Alex to `https://site.example`.
 
-When Alex returns to `https://site.example`, the {{Promise}} returned by `{{Document/allowStorageAccessRequestOnSite()}}` has resolved or will resolve shortly. At this point, requests to `https://idnetity.example` will bear the [=cookie=] set in the previous [=window=].
+When Alex returns to `https://site.example`, the {{Promise}} returned by `{{Document/allowStorageAccessRequestOnSite()}}` has resolved or will resolve shortly. At this point, requests to `https://idnetity.example` will bear the cookie set in the previous [=window=].
 
 </div>
 
@@ -156,8 +156,8 @@ A <dfn>storage access flag set</dfn> is a set of zero or more of the following f
 :: When set, this flag indicates |embedded site| has access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
 : The <dfn for="storage access flag set" id=was-expressly-denied-storage-access-flag>was expressly denied storage access flag</dfn>
 :: When set, this flag indicates that the user expressly denied |embedded site| access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
-: The <dfn for="storage access flag set" id=has-allow-request-storage-access-flag>has allow request storage access flag</dfn>
-:: When set, this flag indicates |top-level site| is allowing |embedded site| to request access to its [=unpartitioned storage=] on |top-level site| from the |embedded site| [=first party context=].
+: The <dfn for="has allow request storage access flag sett" id=has-allow-request-storage-access-flag>has allow request storage access flag</dfn>
+:: When set, this flag indicates |top-level site| is allowing |embedded site| to request access to its [=unpartitioned data=] on |top-level site| from the |embedded site| [=first-party-site context=].
 
 To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partitioned storage key=] |key| from a [=/storage access map=] |map|, run the following steps:
 
@@ -275,7 +275,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|’s [=was expressly denied storage access flag=] is set, 
-    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+    1. Notify all waiting tasks of [{{Document/allowRequestStorageAccessOnSite()}}] with argument corresponding |doc|'s [=site=].
     1. [=resolve=] |p|
     1. return |p|.
 1. If |flag set|’s [=has storage access flag=] is set, 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -98,17 +98,16 @@ Script in the <{iframe}> can call |doc|`.`{{Document/hasStorageAccess()}} to det
 
 </div>
 
-This specification defines a method for a {{Document}} to request access to its [=unpartitioned data=] when later used in a [=third party context=] whose active Document's origin is same-site with a specified site ({{Document/requestStorageAccessUnderSite()}}).
-This specification additionally defines a method for a Document to allow such requests to succeed with arguments that are same-site to its origin in a [=/browsing context=] whose active Document's origin is same-site with a specified site ({{Document/allowStorageAccessRequestOnSite()}}).
+This specification defines two methods that must be called sequentially in top-level contexts to request access to its [=unpartitioned data=] without using iframes, {{Document/completeStorageAccessRequestFromSite()}} and {{Document/requestStorageAccessUnderSite()}}.
 
 <div class=example>
 
-Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and navigates to `https://identity.example` when the returned promise resolves.
+Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, navigates to `https://identity.example` when the returned promise resolves.
 
-Once navigated, Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`.
+Once navigated, Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`, which could ask Alex to give permission for the request.
 Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the [=/browsing context=] navigates, returning Alex to `https://site.example`.
 
-When Alex returns to `https://site.example` requests to `https://identity.example` will bear the cookie set in the previous [=window=].
+When Alex returns to `https://site.example`, the page calls `{{Document.completeStorageAccessRequestFromSite("https://identity.example")}}`. Once the returned promise resolves, requests to `https://identity.example` will bear the cookie set in the previous [=window=].
 
 </div>
 
@@ -178,8 +177,8 @@ To <dfn type="abstract-op">save the storage access flag set</dfn> for a [=partit
 partial interface Document {
   Promise&lt;boolean> hasStorageAccess();
   Promise&lt;undefined> requestStorageAccess();
-  Promise&lt;undefined> allowStorageAccessRequestOnSite(DOMString embeddedURI);
   Promise&lt;undefined> requestStorageAccessUnderSite(DOMString topLevelURI);
+  Promise&lt;undefined> completeStorageAccessRequestFromSite(DOMString embeddedURI);
 };
 </pre>
 
@@ -241,29 +240,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 ISSUE: Shouldn't step 3.7 be [=same site=]?
 
-When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>allowStorageAccessRequestOnSite(DOMString embeddedURI)</code></dfn> method must run these steps:
-
-1. Let |p| be [=a new promise=].
-1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
-1. Let |parsedURI| be the result of running the [=URL parser=] on <var ignore>embeddedURI</var>.
-1. If |parsedURI| is failure, [=reject=] and return |p|.
-1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
-1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
-1. Let |parsedOrigin| be the |parsedURI|'s origin.
-1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
-1. Let |settings| be |doc|'s [=relevant settings object=].
-1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
-1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |parsedOrigin|.
-1. Let |key| be the [=partitioned storage key=] (|site|, |embeddedSite|).
-1. Let |global| be |doc|'s [=relevant global object=].
-1. Run these steps [=in parallel=]:
-    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-    1. Set |flag set|’s [=has allow request storage access flag=].
-    1. [=Save the storage access flag set=] for |key| in |map|.
-    1. [=Resolve=] p.
-1. Return |p|.
-
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString topLevelURI)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
@@ -287,17 +263,41 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |flag set|’s [=has storage access flag=] is set,
     1. [=resolve=] |p|
     1. return |p|.
-1. If the |flag set|'s [=has allow request storage access flag=] is not set,
-    1. [=reject=] |p|
-    1. return |p|.
 1. Otherwise, run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
     1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to
-        1. Set |flag set|'s [=has storage access flag=].
+        1. Set |flag set|'s [=has allow request storage access flag=].
         1. Resolve |p|.
     1. [=Save the storage access flag set=] for |key| in |map|.
 1. Return |p|.
+
+
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>completeStorageAccessRequestFromSite(DOMString embeddedURI)</code></dfn> method must run these steps:
+
+1. Let |p| be [=a new promise=].
+1. Let |parsedURI| be the result of running the [=URL parser=] on <var ignore>embeddedURI</var>.
+1. If |parsedURI| is failure, [=reject=] and return |p|.
+1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
+1. Let |parsedOrigin| be the |parsedURI|'s origin.
+1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
+1. Let |settings| be |doc|'s [=relevant settings object=].
+1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |parsedOrigin|.
+1. Let |key| be the [=partitioned storage key=] (|site|, |embeddedSite|).
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Run these steps [=in parallel=]:
+    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+    1. If |flag set|’s [=has allow request storage access flag=] is set,
+      1. Unset |flag set|'s [=has allow request storage access flag=].
+      1. [=Save the storage access flag set=] for |key| in |map|.
+      1. [=Resolve=] p.
+    1. Otherwise,
+      1. [=Reject=] p
+1. Return |p|.
+
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -74,9 +74,9 @@ urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
 
 <em>This section is non-normative.</em>
 
-User Agents sometimes prevent content inside certain <{iframe}>s from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
+User Agents sometimes prevent third-party content from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
 
-The Storage Access API enables content inside <{iframe}>s to request and be granted access to their client-side storage, so that embedded content which relies on having access to client-side storage can work in such User Agents. [[STORAGE-ACCESS-INTRO]]
+The Storage Access API enables third parties to request and be granted access to their client-side storage, so that embedded content which relies on having access to client-side storage can work in such User Agents. [[STORAGE-ACCESS-INTRO]]
 
 </section>
 
@@ -95,6 +95,18 @@ Alex visits `https://social.example/`. The page sets a cookie. This cookie has b
 Later on, Alex visits `https://video.example/`, which has an <{iframe}> on it which loads `https://social.example/heart-button`. In this case, the `social.example` {{Document}} |doc| is in a [=third party context=], and the cookie set previously might or might not be visible from |doc|`.`{{Document/cookie}}, depending on User Agent storage access policies.
 
 Script in the <{iframe}> can call |doc|`.`{{Document/hasStorageAccess()}} to determine if it has access to the cookie. If it does not have access, it can request access by calling |doc|`.`{{Document/requestStorageAccess()}}.
+
+</div>
+
+This specification also defines a method for a [=site=] to request access to its [=unpartitioned data=] when later loaded in a [=third party context=] on another specified [=site=] ({{Document/requestStorageAccessUnderSite()}}), and a method for a [=site=] to allow such requests to succeed ({{Document/allowStorageAccessRequestOnSite()}}).
+
+<div class=example>
+
+Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and opens a new [=window=] for `https://identity.example`.
+
+In the new [=window=], Alex selects the account to log in with. In response, `https://identity.example` sets a [=cookie=], which by virtue of its [=first party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the `https://identity.example` [=window=] closes itself, returning Alex to `https://site.example`.
+
+When Alex returns to `https://site.example`, the {{Promise}} returned by `{{Document/allowStorageAccessRequestOnSite()}}` has resolved or will resolve shortly. At this point, requests to `https://idnetity.example` will bear the [=cookie=] set in the previous [=window=].
 
 </div>
 
@@ -144,6 +156,8 @@ A <dfn>storage access flag set</dfn> is a set of zero or more of the following f
 :: When set, this flag indicates |embedded site| has access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
 : The <dfn for="storage access flag set" id=was-expressly-denied-storage-access-flag>was expressly denied storage access flag</dfn>
 :: When set, this flag indicates that the user expressly denied |embedded site| access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
+: The <dfn for="storage access flag set" id=has-allow-request-storage-access-flag>has allow request storage access flag</dfn>
+:: When set, this flag indicates |top-level site| is allowing |embedded site| to request access to its [=unpartitioned storage=] on |top-level site| from the |embedded site| [=first party context=].
 
 To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partitioned storage key=] |key| from a [=/storage access map=] |map|, run the following steps:
 
@@ -162,6 +176,8 @@ To <dfn type="abstract-op">save the storage access flag set</dfn> for a [=partit
 partial interface Document {
   Promise&lt;boolean> hasStorageAccess();
   Promise&lt;undefined> requestStorageAccess();
+  Promise&lt;undefined> allowRequestStorageAccessOnSite(DOMString serializedSite);
+  Promise&lt;undefined> requestStorageAccessUnderSite(DOMString serializedSite);
 };
 </pre>
 
@@ -222,6 +238,61 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Return |p|.
 
 ISSUE: Shouldn't step 3.7 be [=same site=]?
+
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>allowRequestStorageAccessOnSite(DOMString serializedSite)</code></dfn> method must run these steps:
+
+1. Let |p| be [=a new promise=].
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
+1. If |serializedEmbeddingSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. Let |settings| be |doc|'s [=relevant settings object=].
+1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
+1. Let |thirdPartySite| be a [=site=] that serializes to |serializedSite|.
+1. Let |key| be the [=partitioned storage key=] (|site|, |thirdPartySite|).
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+1. Set |flag set|’s [=has allow request storage access flag=].
+1. [=Save the storage access flag set=] for |key| in |map|.
+1. Wait for a call to [{{Document/requestStorageAccessUnderSite()}}] on a {{Document}} with [=site=] |thirdPartySite|.
+1. Unset |flag set|’s [=has allow request storage access flag=].
+1. [=Resolve=] and return |p|.
+
+ISSUE: Vagueness around waiting
+ISSUE: Deserialization of site is not well defined
+
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString serializedSite)</code></dfn> method must run these steps:
+
+1. Let |p| be [=a new promise=].
+1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
+1. If |serializedEmbeddingSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. Let |settings| be |doc|'s [=relevant settings object=].
+1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
+1. Let |firstPartySite| be a [=site=] that serializes to |serializedSite|.
+1. Let |key| be the [=partitioned storage key=] (|firstPartySite|, |site|).
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+1. If |flag set|’s [=was expressly denied storage access flag=] is set, 
+    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+    1. [=resolve=] |p|
+    1. return |p|.
+1. If |flag set|’s [=has storage access flag=] is set, 
+    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+    1. [=resolve=] |p|
+    1. return |p|.
+1. Otherwise, run these steps [=in parallel=]:
+    1. Let |hasAccess| be [=a new promise=].
+    1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to
+        1. Set |flag set|'s [=has storage access flag=].
+        1. Resolve |p|.
+    1. [=Save the storage access flag set=] for |key| in |map|.
+1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+1. Return |p|.
+
+
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -74,7 +74,7 @@ urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
 
 <em>This section is non-normative.</em>
 
-User Agents sometimes prevent third-party content from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
+User Agents sometimes prevent content inside certain <{iframe}>s from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
 
 The Storage Access API enables third parties to request and be granted access to their client-side storage, so that embedded content which relies on having access to client-side storage can work in such User Agents. [[STORAGE-ACCESS-INTRO]]
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -98,15 +98,15 @@ Script in the <{iframe}> can call |doc|`.`{{Document/hasStorageAccess()}} to det
 
 </div>
 
-This specification also defines a method for a [=site=] to request access to its [=unpartitioned data=] when later loaded in a [=third party context=] on another specified [=site=] ({{Document/requestStorageAccessUnderSite()}}), and a method for a [=site=] to allow such requests to succeed ({{Document/allowStorageAccessRequestOnSite()}}).
+This specification also defines a method for a site to request access to its [=unpartitioned data=] when later loaded in a [=third party context=] on another specified site ({{Document/requestStorageAccessUnderSite()}}), and a method for a site to allow such requests to succeed ({{Document/allowStorageAccessRequestOnSite()}}).
 
 <div class=example>
 
-Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and opens a new [=window=] for `https://identity.example`.
+Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and opens a new [=window=] for `https://identity.example` when the returned promise resolves.
 
 In the new [=window=], Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the `https://identity.example` [=window=] closes itself, returning Alex to `https://site.example`.
 
-When Alex returns to `https://site.example`, the {{Promise}} returned by `{{Document/allowStorageAccessRequestOnSite()}}` has resolved or will resolve shortly. At this point, requests to `https://idnetity.example` will bear the cookie set in the previous [=window=].
+When Alex returns to `https://site.example` requests to `https://identity.example` will bear the cookie set in the previous [=window=].
 
 </div>
 
@@ -244,7 +244,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>al
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
-1. If |serializedEmbeddingSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. If |serializedSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
 1. Let |thirdPartySite| be a [=site=] that serializes to |serializedSite|.
@@ -254,11 +254,9 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>al
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. Set |flag set|’s [=has allow request storage access flag=].
 1. [=Save the storage access flag set=] for |key| in |map|.
-1. Wait for a call to {{Document/requestStorageAccessUnderSite()}} on a {{Document}} with [=site=] |thirdPartySite|.
 1. Unset |flag set|’s [=has allow request storage access flag=].
 1. [=Resolve=] and return |p|.
 
-ISSUE: Vagueness around waiting
 ISSUE: Deserialization of site is not well defined
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString serializedSite)</code></dfn> method must run these steps:
@@ -266,7 +264,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
-1. If |serializedEmbeddingSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. If |serializedSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
 1. Let |firstPartySite| be a [=site=] that serializes to |serializedSite|.
@@ -274,12 +272,10 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |global| be |doc|'s [=relevant global object=].
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. If |flag set|’s [=was expressly denied storage access flag=] is set, 
-    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+1. If |flag set|’s [=was expressly denied storage access flag=] is set,
     1. [=resolve=] |p|
     1. return |p|.
-1. If |flag set|’s [=has storage access flag=] is set, 
-    1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
+1. If |flag set|’s [=has storage access flag=] is set,
     1. [=resolve=] |p|
     1. return |p|.
 1. Otherwise, run these steps [=in parallel=]:
@@ -289,7 +285,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
         1. Set |flag set|'s [=has storage access flag=].
         1. Resolve |p|.
     1. [=Save the storage access flag set=] for |key| in |map|.
-1. Notify all waiting tasks of {{Document/allowRequestStorageAccessOnSite()}} with argument corresponding |doc|'s [=site=].
 1. Return |p|.
 
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -74,9 +74,9 @@ urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
 
 <em>This section is non-normative.</em>
 
-User Agents sometimes prevent content inside certain <{iframe}>s from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
+User Agents sometimes prevent content inside certain <{iframe}>s or requests from accessing data stored in client-side storage mechanisms like cookies. This can break embedded content which relies on having access to client-side storage.
 
-The Storage Access API enables third parties to request and be granted access to their client-side storage, so that embedded content which relies on having access to client-side storage can work in such User Agents. [[STORAGE-ACCESS-INTRO]]
+The Storage Access API enables Documents to request and be granted access to their unpartitioned client-side storage, so that embedded content which relies on having access to client-side storage can work in such User Agents. [[STORAGE-ACCESS-INTRO]]
 
 </section>
 
@@ -98,13 +98,14 @@ Script in the <{iframe}> can call |doc|`.`{{Document/hasStorageAccess()}} to det
 
 </div>
 
-This specification also defines a method for a site to request access to its [=unpartitioned data=] when later loaded in a [=third party context=] on another specified site ({{Document/requestStorageAccessUnderSite()}}), and a method for a site to allow such requests to succeed ({{Document/allowStorageAccessRequestOnSite()}}).
+This specification defines a method for a {{Document}} to request access to its [=unpartitioned data=] when later used in a [=third party context=] whose active Document's origin is same-site with a specified site ({{Document/requestStorageAccessUnderSite()}}).
+This specification additionally defines a method for a Document to allow such requests to succeed with arguments that are same-site to its origin in a [=browsing context=] whose active Document's origin is same-site with a specified site ({{Document/allowStorageAccessRequestOnSite()}}).
 
 <div class=example>
 
-Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and opens a new [=window=] for `https://identity.example` when the returned promise resolves.
+Alex visits `https://site.example`. Alex clicks "Login with Identity", which Alex expects to log them in with their account on `https://identity.example`. The page, `https://site.example`, calls `{{Document.allowStorageAccessRequestOnSite("https://identity.example")}}` and navigates to `https://identity.example` when the returned promise resolves.
 
-In the new [=window=], Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the `https://identity.example` [=window=] closes itself, returning Alex to `https://site.example`.
+Once navigated, Alex selects the account to log in with. In response, `https://identity.example` sets a cookie, which by virtue of its [=first-party-site context=] is in its [=unpartitioned data=] and calls `{{Document.requestStorageAccessUnderSite("https://site.example")}}`. Once the {{Promise}} returned by `{{Document/requestStorageAccessUnderSite()}}` resolves, the [=browsing context=] navigates, returning Alex to `https://site.example`.
 
 When Alex returns to `https://site.example` requests to `https://identity.example` will bear the cookie set in the previous [=window=].
 
@@ -176,8 +177,8 @@ To <dfn type="abstract-op">save the storage access flag set</dfn> for a [=partit
 partial interface Document {
   Promise&lt;boolean> hasStorageAccess();
   Promise&lt;undefined> requestStorageAccess();
-  Promise&lt;undefined> allowStorageAccessRequestOnSite(DOMString serializedSite);
-  Promise&lt;undefined> requestStorageAccessUnderSite(DOMString serializedSite);
+  Promise&lt;undefined> allowStorageAccessRequestOnSite(DOMString embeddedURI);
+  Promise&lt;undefined> requestStorageAccessUnderSite(DOMString topLevelURI);
 };
 </pre>
 
@@ -239,44 +240,56 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 ISSUE: Shouldn't step 3.7 be [=same site=]?
 
-When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>allowRequestStorageAccessOnSite(DOMString serializedSite)</code></dfn> method must run these steps:
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>allowStorageAccessRequestOnSite(DOMString embeddedURI)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
+1. Let |parsedURI| be the result of parsing |embeddedURI|.
+1. If |parsedURI| is failure, [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
-1. If |serializedSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
+1. Let |parsedOrigin| be the result of obtaining the origin of |parsedURI|.
+1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
-1. Let |thirdPartySite| be a [=site=] that serializes to |serializedSite|.
-1. Let |key| be the [=partitioned storage key=] (|site|, |thirdPartySite|).
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |parsedOrigin|.
+1. Let |key| be the [=partitioned storage key=] (|site|, |embeddedSite|).
 1. Let |global| be |doc|'s [=relevant global object=].
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. Set |flag set|’s [=has allow request storage access flag=].
-1. [=Save the storage access flag set=] for |key| in |map|.
-1. Unset |flag set|’s [=has allow request storage access flag=].
-1. [=Resolve=] and return |p|.
+1. Run these steps [=in parallel=]:
+    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
+    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+    1. Set |flag set|’s [=has allow request storage access flag=].
+    1. [=Save the storage access flag set=] for |key| in |map|.
+    1. [=Resolve=] p.
+1. Return |p|.
 
 ISSUE: Deserialization of site is not well defined
 
-When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString serializedSite)</code></dfn> method must run these steps:
+When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccessUnderSite(DOMString topLevelURI)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
+1. Let |parsedURI| be the result of parsing |embeddedURI|.
+1. If |parsedURI| is failure, [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is not a [=top-level browsing context=], [=reject=] and return |p|.
-1. If |serializedSite| is |"null"| or not a valid [=serialization of a site=], [=reject=] and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
+1. Let |parsedOrigin| be the result of obtaining the origin of |parsedURI|.
+1. If |doc|'s [=Document/origin=] is same site to |parsedOrigin|, [=reject=] and return |p|.
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
-1. Let |firstPartySite| be a [=site=] that serializes to |serializedSite|.
-1. Let |key| be the [=partitioned storage key=] (|firstPartySite|, |site|).
+1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |parsedOrigin|.
+1. Let |key| be the [=partitioned storage key=] (|topLevelSite|, |site|).
 1. Let |global| be |doc|'s [=relevant global object=].
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|’s [=was expressly denied storage access flag=] is set,
-    1. [=resolve=] |p|
+    1. [=reject=] |p|
     1. return |p|.
 1. If |flag set|’s [=has storage access flag=] is set,
     1. [=resolve=] |p|
+    1. return |p|.
+1. If the |flag set|'s [=has allow request storage access flag=] is not set,
+    1. [=reject=] |p|
     1. return |p|.
 1. Otherwise, run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].


### PR DESCRIPTION
Building upon [this explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/pull/524/files#diff-ffc71381526693d6f530b29e4590bd1983dc2532242d52a389beb47f98f636ad) and the discussion in #83 , this is a rough draft of a proposal for a forward declared API.

Looking for thoughts, comments, and potential improvements.

Especially rough is how to handle timing between the first and third party pages. I use the language "wait" and "notify" which is not as precise as the rest of the language in the spec, but gets the point across to get discussion rolling.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bvandersloot-mozilla/storage-access/pull/100.html" title="Last updated on Jun 28, 2022, 7:13 PM UTC (6aabaea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/100/2d880e4...bvandersloot-mozilla:6aabaea.html" title="Last updated on Jun 28, 2022, 7:13 PM UTC (6aabaea)">Diff</a>