### PR TITLE
Change permissions policy feature name to "storage-access" (fixes #104)

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -200,7 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
-1. If |doc| is not [=allowed to use=] the `"request-storage-access"` permission, [=reject=] and return |p|.
+1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] and return |p|.
@@ -297,7 +297,7 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 
 <h2 id="permissions-policy-integration">Permissions Policy Integration</h2>
 
-The Storage Access API defines a [=policy-controlled feature=] identified by the string `"request-storage-access"`. Its [=default allowlist=] is `"*"`.
+The Storage Access API defines a [=policy-controlled feature=] identified by the string `"storage-access"`. Its [=default allowlist=] is `"*"`.
 
     Note: A {{Document}}’s [=Document/permissions policy=] determines whether any content in that document is allowed to request storage access using {{Document/requestStorageAccess()}}. If disabled in any document, calling {{Document/requestStorageAccess()}} in that document will reject.
 


### PR DESCRIPTION
This was discussed before in #12 and there was some valid concern around
the "storage-access" name based on the fact that this PP feature is more
focused on "requesting" storage access, and there is no delegation
mechanism like with other permissions that would make it semantically
consistent.

However, I think that in light of #32 and the possibility of integrating
with the permissions API (giving us important functionality such as
observing when storage access is granted) it seems more useful to be
consistent with the (future) permission name and call both "storage-access".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/storage-access/pull/105.html" title="Last updated on Jul 18, 2022, 6:33 PM UTC (d1d54fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/105/1323cbc...johannhof:d1d54fc.html" title="Last updated on Jul 18, 2022, 6:33 PM UTC (d1d54fc)">Diff</a>