### PR TITLE
Specify behavior for non-fully active documents

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -173,6 +173,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15512 -->
 
 1. Let |p| be [=a new promise=].
+1. If |doc| is not [=Document/fully active=], then [=reject=] and return |p| with a "{{SecurityError}}" {{DOMException}}.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
@@ -199,6 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15629 -->
 
 1. Let |p| be [=a new promise=].
+1. If |doc| is not [=Document/fully active=], then [=reject=] and return |p| with a "{{SecurityError}}" {{DOMException}}.
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] and return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -173,7 +173,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15512 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] and return |p| with a "{{SecurityError}}" {{DOMException}}.
+1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with a "{{SecurityError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
@@ -200,7 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15629 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] and return |p| with a "{{SecurityError}}" {{DOMException}}.
+1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with a "{{SecurityError}}" {{DOMException}} and return |p|.
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] and return |p|.


### PR DESCRIPTION
Please see discussion in https://crbug.com/1354256 for context.
The particular case that started this discussion was behavior in
detached frames.
The wording was largely pulled from:
https://github.com/whatwg/webidl/blob/main/index.bs#L8510-L8511


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mreichhoff/storage-access/pull/108.html" title="Last updated on Aug 18, 2022, 9:35 PM UTC (c187ddb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/108/104dbe5...mreichhoff:c187ddb.html" title="Last updated on Aug 18, 2022, 9:35 PM UTC (c187ddb)">Diff</a>