### PR TITLE
Use InvalidStateError instead of SecurityError for fully active checks

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -174,7 +174,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15512 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with a "{{SecurityError}}" {{DOMException}} and return |p|.
+1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
@@ -201,7 +201,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15629 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with a "{{SecurityError}}" {{DOMException}} and return |p|.
+1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] and return |p|.


### PR DESCRIPTION
@mreichhoff I noticed that InvalidStateError seems to be the most common error state for non-fully active checks, is there any particular reason we picked a SecurityError in Chromium for this?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/storage-access/pull/112.html" title="Last updated on Sep 2, 2022, 11:42 AM UTC (a1a1a41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/112/7e9c01f...johannhof:a1a1a41.html" title="Last updated on Sep 2, 2022, 11:42 AM UTC (a1a1a41)">Diff</a>