### PR TITLE
Make implicit and explicit deny indistinguishable

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -244,6 +244,8 @@ To <dfn type="abstract-op">determine if a site has storage access</dfn> with [=p
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for [=partitioned storage key=] |key| with {{Document}} |doc| and {{Promise}} |p|, run these steps:
 
+1. [=Run steps after a timeout=] given |doc|'s {{Window}} object, `"requestStorageAccess"`, `120000`, and the following steps:
+    1. If |p| is pending, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded site=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
@@ -251,7 +253,7 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for [=parti
     Note: These [=implementation-defined=] set of steps might result in |flag set|'s [=has storage access flag=] and [=was expressly denied storage access flag=] changing, since the User Agent could have relevant out-of-band information (e.g. a user preference that changed) that this specification is unaware of.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. If |implicitly denied| is true, return.
 1. Ask the user if they would like to grant |key|'s [=partitioned storage key/embedded site=] access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |key|'s [=partitioned storage key/top-level site=], and wait for an answer. Let |expressly granted| and |expressly denied| (both [=booleans=]) be the result.
 
     Note: While |expressly granted| and |expressly denied| cannot both be true, they could both be false in User Agents which allow users to dismiss the prompt without choosing to allow or deny the request. (Such a dismissal is interpreted in this algorithm as a denial.)
@@ -264,7 +266,6 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for [=parti
     1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
     1. Set |flag set|'s [=was expressly denied storage access flag=].
 1. [=Save the storage access flag set=] for |key| in |map|.
-1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 ISSUE: [since this is UA-defined, does it make sense to follow-up separately with a user prompt?](https://github.com/privacycg/storage-access/pull/24#discussion_r408784492)
 


### PR DESCRIPTION
This is accomplished by adding a 2-minute timeout to reject an unfulfilled promise immediately before checking for implicit denies and not rejecting the promise when the implicit or explicit deny occurs.

I am open to hearing better ways to specify a timeout or Promise fulfillment testing.

I am also open to discussion of removing the timeout entirely and allowing the Promise to leak. 