### PR TITLE
Restrict usage to within a secure context.

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -177,13 +177,13 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. If |global| is not a [=secure context=], then [=resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. If |key| is failure, [=resolve=] |p| with false and return |p|.
-1. Let |global| be |doc|'s [=relevant global object=].
-1. If |global| is not a [=secure context=], then [=resolve=] |p| with false and return |p|.
 1. Run these steps [=in parallel=]:
     1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
     1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
@@ -194,7 +194,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with the result of |hasAccess|.
 1. Return |p|.
 
-ISSUE: Shouldn't step 7 be [=same site=]?
+ISSUE: Shouldn't step 8 be [=same site=]?
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:
 
@@ -204,6 +204,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
@@ -213,8 +215,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. If |key| is failure, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. Let |global| be |doc|'s [=relevant global object=].
-1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
@@ -228,7 +228,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. [=Save the storage access flag set=] for |key| in |map|.
 1. Return |p|.
 
-ISSUE: Shouldn't step 3.7 be [=same site=]?
+ISSUE: Shouldn't step 9 be [=same site=]?
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -183,6 +183,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. If |key| is failure, [=resolve=] |p| with false and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
+1. If |global| is not a [=secure context=], then [=resolve=] |p| with false and return |p|.
 1. Run these steps [=in parallel=]:
     1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
     1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
@@ -213,6 +214,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. If |key| is failure, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
+1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.


### PR DESCRIPTION
This PR restricts usage of the API to within a secure context, and closes https://github.com/privacycg/storage-access/issues/125. As the Storage Access API is intended to address authenticated embeds while protecting user privacy, this change is not expected to be controversial.

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://crrev.com/c/3991336
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1380155
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1798407
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=247286

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/storage-access/pull/132.html" title="Last updated on Oct 31, 2022, 9:22 PM UTC (24883f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/132/c7abefa...cfredric:24883f6.html" title="Last updated on Oct 31, 2022, 9:22 PM UTC (24883f6)">Diff</a>