### PR TITLE
Modify Storage Access to use a "per-frame" model

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -121,11 +121,11 @@ A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-
 <h3 id="ua-state">Changes to User Agent state related to storage access</h3>
 
 Modify the definition of [=environment=] in the following manner:
-1. Add a new member called <dfn for="environment">obtained storage access flag</dfn> of type boolean.
+1. Add a new member called <dfn for="environment">has storage access flag</dfn> of type [=boolean=].
 
 Modify the definition of [=source snapshot params=] in the following manner:
-1. Add a new member called <dfn for="source snapshot params">obtained storage access flag</dfn> of type boolean.
-1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque string.
+1. Add a new member called <dfn for="source snapshot params">has storage access flag</dfn> of type [=boolean=].
+1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque [=string=].
 
 A <dfn>partitioned storage key</dfn> is a [=tuple=] consisting of a <dfn for="partitioned storage key">top-level site</dfn> (a [=site=]) and an <dfn for="partitioned storage key">embedded origin</dfn> (an [=/origin=]).
 
@@ -166,7 +166,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
-1. [=Resolve=] or [=reject=] |p| based on |global|'s [=environment/obtained storage access flag=].
+1. [=Resolve=] or [=reject=] |p| based on |global|'s [=environment/has storage access flag=].
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -187,7 +187,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/obtained storage access flag=] is true, [=resolve=] and return |p|.
+1. If |global|'s [=environment/has storage access flag=] is true, [=resolve=] and return |p|.
 1. Otherwise, run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
     1. [=Determine the storage access policy=] with |doc| and |hasAccess|.
@@ -203,14 +203,18 @@ Different User Agents have different policies around whether or not [=sites=] ma
 To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{Document}} |doc|, run these steps:
 
 1. Let |global| be |doc|'s [=relevant global object=].
-1. Return |global|'s [=environment/obtained storage access flag=].
+1. Return |global|'s [=environment/has storage access flag=].
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
 
 1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
 1. If |previousPermissionState| is not [=permission/prompt=]:
-    1. Set |global|'s [=environment/obtained storage access flag=] based on whether |previousPermissionState| is [=permission/granted=] or [=permission/denied=].
-    1. [=/Resolve=] or [=/reject=] |p| (with a "{{NotAllowedError}}" {{DOMException}}) based on whether |previousPermissionState| is [=permission/granted=] or [=permission/denied=].
+    1. If |previousPermissionState| is [=permission/granted=]:
+        1. Set |global|'s [=environment/has storage access flag=] to true. Set |global|'s [=environment/has storage access flag=] to false.
+        1. [=/Resolve=] |p|.
+        1. Return.
+    1. Set |global|'s [=environment/has storage access flag=] to false.
+    1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
 1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
@@ -221,28 +225,28 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Docum
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
 1. If |permissionState| is "granted":
     1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-        1. Set |global|'s [=environment/obtained storage access flag=] to true.
+        1. Set |global|'s [=environment/has storage access flag=] to true.
         1. [=/Resolve=] |p|.
     1. Return.
-1. Set |global|'s [=environment/obtained storage access flag=] to false.
+1. Set |global|'s [=environment/has storage access flag=] to false.
 1. [=Consume user activation=] given |doc|'s {{Window}} object.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>
 
 When [=snapshotting source snapshot params=]:
-1. Set [=source snapshot params/obtained storage access flag=] to |sourceDocument|'s [=source snapshot params/obtained storage access flag=].
+1. Set [=source snapshot params/has storage access flag=] to |sourceDocument|'s [=source snapshot params/has storage access flag=].
 1. Set [=source snapshot params/environment id=] to |sourceDocument|'s [=relevant settings object=]'s [=environment/id=].
 
 When creating |request|'s [=reserved client=] in [=create navigation params by fetching=]:
-1. Set the [=reserved client=]'s [=environment/obtained storage access flag=] to be |sourceSnapshotParams|'s [=source snapshot params/obtained storage access flag=] if:
+1. Set the [=reserved client=]'s [=environment/has storage access flag=] to be |sourceSnapshotParams|'s [=source snapshot params/has storage access flag=] if:
     1. |sourceSnapshotParams|'s [=source snapshot params/environment id=] equals <var ignore>navigable</var>'s [=active document=]'s [=relevant settings object=]'s [=environment/id=].
     1. <var ignore>entry</var>'s URL is [=same origin=] with <var ignore>currentURL</var>.
     1. |response| is null or |response|'s [=response/has-cross-origin-redirects=] is false.
-1. Otherwise, set |request|'s [=reserved client=]'s [=environment/obtained storage access flag=] to false.
+1. Otherwise, set |request|'s [=reserved client=]'s [=environment/has storage access flag=] to false.
 
 When [=set up a window environment settings object|setting up a window environment settings object=]:
-1. Set <var ignore>settings object</var>'s [=environment/obtained storage access flag=] to <var ignore>reserved environment</var>'s [=environment/obtained storage access flag=].
+1. Set <var ignore>settings object</var>'s [=environment/has storage access flag=] to <var ignore>reserved environment</var>'s [=environment/has storage access flag=].
 
 
 ISSUE(privacycg/storage-access#3): What this section should look like ultimately hinges on

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -285,9 +285,13 @@ The Storage Access API defines a [=powerful feature=] identified by the [=powerf
 
         Note: The "denied" permission state is not revealed to avoid exposing the user's decision to developers. This is done to prevent retaliation against the user and repeated prompting to the detriment of the user experience.
   </dd>
+  <dt>[=powerful feature/permission key type]</dt>
+  <dd>
+    A [=permission key] of the "<a permission><code>storage-access</code></a>" feature has the type ([=site=], [=/origin=]).
+  </dd>
   <dt>[=powerful feature/permission key generation algorithm]</dt>
   <dd>
-    To generate a new [=permission store key] for the "<a permission><code>storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
+    To generate a new [=permission key] for the "<a permission><code>storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
 
     1. Let |topLevelSite| be |settings|' [=top-level site=].
     1. Let |embeddedOrigin| be |settings|' [=environment settings object/origin=].

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -118,13 +118,13 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
-<h3 id="ua-state">Changes to User Agent state related to storage access</h3>
+<h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
 Modify the definition of [=environment=] in the following manner:
-1. Add a new member called <dfn for="environment">has storage access flag</dfn> of type [=boolean=].
+1. Add a new member called <dfn for="environment">has storage access</dfn> of type [=boolean=].
 
 Modify the definition of [=source snapshot params=] in the following manner:
-1. Add a new member called <dfn for="source snapshot params">has storage access flag</dfn> of type [=boolean=].
+1. Add a new member called <dfn for="source snapshot params">has storage access</dfn> of type [=boolean=].
 1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque [=string=].
 
 A <dfn>partitioned storage key</dfn> is a [=tuple=] consisting of a <dfn for="partitioned storage key">top-level site</dfn> (a [=site=]) and an <dfn for="partitioned storage key">embedded origin</dfn> (an [=/origin=]).
@@ -166,7 +166,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
-1. [=Resolve=] or [=reject=] |p| based on |global|'s [=environment/has storage access flag=].
+1. [=Resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -187,11 +187,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access flag=] is true, [=resolve=] and return |p|.
-1. Otherwise, run these steps [=in parallel=]:
-    1. Let |hasAccess| be [=a new promise=].
-    1. [=Determine the storage access policy=] with |doc| and |hasAccess|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
+1. If |global|'s [=environment/has storage access=] is true, [=resolve=] and return |p|.
+1. [=Determine the storage access policy=] with |doc| and |p|.
 1. Return |p|.
 
 ISSUE: Shouldn't step 9 be [=same site=]?
@@ -203,17 +200,17 @@ Different User Agents have different policies around whether or not [=sites=] ma
 To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{Document}} |doc|, run these steps:
 
 1. Let |global| be |doc|'s [=relevant global object=].
-1. Return |global|'s [=environment/has storage access flag=].
+1. Return |global|'s [=environment/has storage access=].
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
 
 1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
 1. If |previousPermissionState| is not [=permission/prompt=]:
     1. If |previousPermissionState| is [=permission/granted=]:
-        1. Set |global|'s [=environment/has storage access flag=] to true. Set |global|'s [=environment/has storage access flag=] to false.
+        1. Set |global|'s [=environment/has storage access=] to true. Set |global|'s [=environment/has storage access=] to false.
         1. [=/Resolve=] |p|.
         1. Return.
-    1. Set |global|'s [=environment/has storage access flag=] to false.
+    1. Set |global|'s [=environment/has storage access=] to false.
     1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
 1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
@@ -225,28 +222,28 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Docum
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
 1. If |permissionState| is "granted":
     1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-        1. Set |global|'s [=environment/has storage access flag=] to true.
+        1. Set |global|'s [=environment/has storage access=] to true.
         1. [=/Resolve=] |p|.
     1. Return.
-1. Set |global|'s [=environment/has storage access flag=] to false.
+1. Set |global|'s [=environment/has storage access=] to false.
 1. [=Consume user activation=] given |doc|'s {{Window}} object.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>
 
 When [=snapshotting source snapshot params=]:
-1. Set [=source snapshot params/has storage access flag=] to |sourceDocument|'s [=source snapshot params/has storage access flag=].
+1. Set [=source snapshot params/has storage access=] to |sourceDocument|'s [=source snapshot params/has storage access=].
 1. Set [=source snapshot params/environment id=] to |sourceDocument|'s [=relevant settings object=]'s [=environment/id=].
 
 When creating |request|'s [=reserved client=] in [=create navigation params by fetching=]:
-1. Set the [=reserved client=]'s [=environment/has storage access flag=] to be |sourceSnapshotParams|'s [=source snapshot params/has storage access flag=] if:
+1. Set [=reserved client=]'s [=environment/has storage access=] to |sourceSnapshotParams|'s [=source snapshot params/has storage access=] if:
     1. |sourceSnapshotParams|'s [=source snapshot params/environment id=] equals <var ignore>navigable</var>'s [=active document=]'s [=relevant settings object=]'s [=environment/id=].
     1. <var ignore>entry</var>'s URL is [=same origin=] with <var ignore>currentURL</var>.
     1. |response| is null or |response|'s [=response/has-cross-origin-redirects=] is false.
-1. Otherwise, set |request|'s [=reserved client=]'s [=environment/has storage access flag=] to false.
+1. Otherwise, set |request|'s [=reserved client=]'s [=environment/has storage access=] to false.
 
 When [=set up a window environment settings object|setting up a window environment settings object=]:
-1. Set <var ignore>settings object</var>'s [=environment/has storage access flag=] to <var ignore>reserved environment</var>'s [=environment/has storage access flag=].
+1. Set <var ignore>settings object</var>'s [=environment/has storage access=] to <var ignore>reserved environment</var>'s [=environment/has storage access=].
 
 
 ISSUE(privacycg/storage-access#3): What this section should look like ultimately hinges on

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -187,7 +187,8 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. [=Determine the storage access policy=] with |doc| and |p|.
+1. Run the following steps in parallel:
+    1. [=Determine the storage access policy=] with |doc| and |p|.
 1. Return |p|.
 
 ISSUE: Shouldn't step 9 be [=same site=]?

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -143,8 +143,6 @@ A <dfn>storage access flag set</dfn> is a set of zero or more of the following f
 
 : The <dfn for="storage access flag set" id=has-storage-access-flag>has storage access flag</dfn>
 :: When set, this flag indicates |embedded origin| has access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
-: The <dfn for="storage access flag set" id=was-expressly-denied-storage-access-flag>was expressly denied storage access flag</dfn>
-:: When set, this flag indicates that the user expressly denied |embedded origin| access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
 
 To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partitioned storage key=] |key| from a [=/storage access map=] |map|, run the following steps:
 
@@ -152,10 +150,6 @@ To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partit
     1. Let |flags| be a new [=storage access flag set=].
     1. [=map/Set=] |map|[|key|] to |flags|.
 1. Return |map|[|key|].
-
-To <dfn type="abstract-op">save the storage access flag set</dfn> for a [=partitioned storage key=] |key| in a [=/storage access map=] |map|, run the following steps:
-
-1. [=map/Set=] [=global storage access map=][|key|] to |map|[|key|].
 
 <h3 id="the-document-object">Changes to {{Document}}</h3>
 
@@ -182,14 +176,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. If |key| is failure, [=resolve=] |p| with false and return |p|.
-1. Run these steps [=in parallel=]:
-    1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-    1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-    1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with false, and abort these steps.
-    1. If |flag set|'s [=has storage access flag=] is set, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with true, and abort these steps.
-    1. Let |hasAccess| be [=a new promise=].
-    1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with the result of |hasAccess|.
+1. [=Resolve=] or [=reject=] |p| based on the result of running [=determine if a site has storage access=] with |key| and |doc|.
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -215,7 +202,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |key| is failure, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. If |flag set|'s [=was expressly denied storage access flag=] is set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |flag set|'s [=has storage access flag=] is set, [=/resolve=] and return |p|.
 1. Otherwise, run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
@@ -223,7 +209,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. [=Queue a global task=] on the [=permission task source=] given |global| to
         1. Set |flag set|'s [=has storage access flag=].
         1. Resolve or reject |p| based on the result of |hasAccess|.
-    1. [=Save the storage access flag set=] for |key| in |map|.
 1. Return |p|.
 
 ISSUE: Shouldn't step 9 be [=same site=]?
@@ -237,36 +222,21 @@ To <dfn type="abstract-op">determine if a site has storage access</dfn> with [=p
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. If |flag set|'s [=has storage access flag=] is set, return true.
-1. Let |has storage access| (a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=] has access to its [=unpartitioned data=] on |key|'s [=partitioned storage key/top-level site=].
-1. If |has storage access| is true, set |flag set|'s [=has storage access flag=].
-1. [=Save the storage access flag set=] for |key| in |map|.
-1. Return |has storage access|.
+1. Return false.
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for [=partitioned storage key=] |key| with {{Document}} |doc| and {{Promise}} |p|, run these steps:
 
 1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
-
-    Note: These [=implementation-defined=] set of steps might result in |flag set|'s [=has storage access flag=] and [=was expressly denied storage access flag=] changing, since the User Agent could have relevant out-of-band information (e.g. a user preference that changed) that this specification is unaware of.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
-1. Ask the user if they would like to grant |key|'s [=partitioned storage key/embedded origin=] access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |key|'s [=partitioned storage key/top-level site=], and wait for an answer. Let |expressly granted| and |expressly denied| (both [=booleans=]) be the result.
-
-    Note: While |expressly granted| and |expressly denied| cannot both be true, they could both be false in User Agents which allow users to dismiss the prompt without choosing to allow or deny the request. (Such a dismissal is interpreted in this algorithm as a denial.)
-1. If |expressly granted| is true, run these steps:
-    1. Unset |flag set|'s [=was expressly denied storage access flag=].
-    1. [=Save the storage access flag set=] for |key| in |map|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
+1. Let |permissionState| be the result of [=requesting permission to use=] "storage-access".
+1. If |permissionState| is "granted", [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. Unset |flag set|'s [=has storage access flag=].
-1. If |expressly denied| is true, run these steps:
-    1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
-    1. Set |flag set|'s [=was expressly denied storage access flag=].
-1. [=Save the storage access flag set=] for |key| in |map|.
+1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-
-ISSUE: [since this is UA-defined, does it make sense to follow-up separately with a user prompt?](https://github.com/privacycg/storage-access/pull/24#discussion_r408784492)
 
 <h3 id="navigation">Changes to navigation</h3>
 
@@ -278,7 +248,6 @@ Before changing the current entry of a session history, run the following steps:
 1. If |key| is failure, abort these steps.
 1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
 1. Unset |flag set|'s [=has storage access flag=].
-1. [=Save the storage access flag set=] for |key| in |map|.
 
 ISSUE(privacycg/storage-access#3): What this section should look like ultimately hinges on
 
@@ -301,6 +270,30 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 <ul>
 <li>The [=sandbox storage access by user activation flag=], unless <var ignore>tokens</var> contains the <dfn export attr-value for=iframe/sandbox>allow-storage-access-by-user-activation</dfn> keyword.
 </ul>
+
+<h2 id="permissions-integration">Permissions Integration</h2>
+
+The Storage Access API defines a [=powerful feature=] identified by the [=powerful feature/name=] `"storage-access"`.
+
+<h3 id="permissions-key-generate">Changes to generate a permission store key</h3>
+
+Update the generate a permission store key algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
+
+1. If |name| is "storage-access", run the following steps:
+    1. Let |topLevelOrigin| be |settings|' [=environment/top-level origin].
+    1. Let |embeddedOrigin| be |settings|' [=environment/origin].
+    1. Return (|topLevelOrigin|, |embeddedOrigin|).
+
+<h3 id="permissions-key-compare">Changes to compare permission store keys</h3>
+
+Update the compare permission store keys algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
+
+1. If |name| is "storage-access", run the following steps:
+    1. Let |topLevelSite1| be the result of [=obtaining a site=] from |key1|'s permission store key/top-level origin.
+    1. Let |topLevelSite2| be the result of [=obtaining a site=] from |key2|'s permission store key/top-level origin.
+    1. If |topLevelSite1| is not [=same site=] with |topLevelSite2|, return false.
+    1. If |key1|'s permission store key/granted origin is not [=same origin=] with |key2|'s permission store key/granted origin, return false.
+    1. Return true.
 
 <h2 id="permissions-policy-integration">Permissions Policy Integration</h2>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -44,6 +44,19 @@ urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
         text: unsupported operation; url: dfn-unsupported-operation
         text: session; url: dfn-session
         text: success; url: dfn-success
+
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
+    type: dfn
+        text: source snapshot params; url: browsing-the-web.html#source-snapshot-params
+        text: snapshotting source snapshot params; url: browsing-the-web.html#snapshotting-source-snapshot-params
+        text: create navigation params by fetching; url: browsing-the-web.html#create-navigation-params-by-fetching
+        text: set up a window environment settings object; url: nav-history-apis.html#set-up-a-window-environment-settings-object
+        text: environment
+
+spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
+    type: dfn
+        for: response
+            text: has-cross-origin-redirects; url: #response-has-cross-origin-redirects
 </pre>
 
 <pre class=biblio>
@@ -105,23 +118,14 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
-<h3 id="ua-state">User Agent state related to storage access</h3>
+<h3 id="ua-state">Changes to User Agent state related to storage access</h3>
 
-A <dfn>storage access map</dfn> is a [=map=] whose keys are [=partitioned storage keys=] and whose values are [=storage access flag sets=].
+Modify the definition of [=environment=] in the following manner:
+1. Add a new member called <dfn for="environment">obtained storage access flag</dfn> of type boolean.
 
-User Agents maintain a single <dfn>global storage access map</dfn>.
-
-ISSUE(privacycg/storage-access#2): What is the lifecycle of the [=global storage access map=]? How long do we remember its contents? Firefox and Safari differ here.
-
-ISSUE(privacycg/storage-access#5): When do we age out entries in the [=global storage access map=]? See also [Scope of Storage Access](https://github.com/privacycg/storage-access#scope-of-storage-access).
-
-Each [=agent cluster=] has a <dfn for="agent cluster">storage access map</dfn>.
-
-When an [=agent cluster=] is created, its [=agent cluster/storage access map=] is initialized with a [=map/clone=] of the [=global storage access map=].
-
-To <dfn type="abstract-op">obtain the storage access map</dfn> for a {{Document}} |doc|, run the following steps:
-
-1. Return the [=agent cluster/storage access map=] of |doc|'s [=relevant agent=]'s [=agent cluster=].
+Modify the definition of [=source snapshot params=] in the following manner:
+1. Add a new member called <dfn for="source snapshot params">obtained storage access flag</dfn> of type boolean.
+1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque string.
 
 A <dfn>partitioned storage key</dfn> is a [=tuple=] consisting of a <dfn for="partitioned storage key">top-level site</dfn> (a [=site=]) and an <dfn for="partitioned storage key">embedded origin</dfn> (an [=/origin=]).
 
@@ -138,18 +142,6 @@ To <dfn type="abstract-op">generate a partitioned storage key</dfn> for a {{Docu
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], return the [=partitioned storage key=] (|site|, |site|).
 1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
 1. Return the [=partitioned storage key=] (|top-level site|, |site|).
-
-A <dfn>storage access flag set</dfn> is a set of zero or more of the following flags, which are used to gate access to client-side storage for |embedded origin| when loaded in a [=third party context=] on |top-level site|:
-
-: The <dfn for="storage access flag set" id=has-storage-access-flag>has storage access flag</dfn>
-:: When set, this flag indicates |embedded origin| has access to its [=unpartitioned data=] when it's loaded in a [=third party context=] on |top-level site|.
-
-To <dfn type="abstract-op">obtain a storage access flag set</dfn> for a [=partitioned storage key=] |key| from a [=/storage access map=] |map|, run the following steps:
-
-1. If |map|[|key|] [=map/exists|does not exist=], run these steps:
-    1. Let |flags| be a new [=storage access flag set=].
-    1. [=map/Set=] |map|[|key|] to |flags|.
-1. Return |map|[|key|].
 
 <h3 id="the-document-object">Changes to {{Document}}</h3>
 
@@ -174,9 +166,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
-1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. If |key| is failure, [=resolve=] |p| with false and return |p|.
-1. [=Resolve=] or [=reject=] |p| based on the result of running [=determine if a site has storage access=] with |key| and |doc|.
+1. [=Resolve=] or [=reject=] |p| based on |global|'s [=environment/obtained storage access flag=].
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -198,56 +188,57 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. If |key| is failure, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. If |flag set|'s [=has storage access flag=] is set, [=/resolve=] and return |p|.
+1. If |global|'s [=environment/obtained storage access flag=] is true, [=resolve=] and return |p|.
 1. Otherwise, run these steps [=in parallel=]:
     1. Let |hasAccess| be [=a new promise=].
-    1. [=Determine the storage access policy=] with |key|, |doc| and |hasAccess|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to
-        1. Set |flag set|'s [=has storage access flag=].
-        1. Resolve or reject |p| based on the result of |hasAccess|.
+    1. [=Determine the storage access policy=] with |doc| and |hasAccess|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
 1. Return |p|.
 
-ISSUE: Shouldn't step 9 be [=same site=]?
+ISSUE: Shouldn't step 10 be [=same site=]?
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 
 Different User Agents have different policies around whether or not [=sites=] may access their [=unpartitioned data=] when they're in a [=third party context=]. User Agents check and/or modify these policies when client-side storage is accessed (see [[#storage]]) as well as when {{Document/hasStorageAccess()}} and {{Document/requestStorageAccess()}} are called.
 
-To <dfn type="abstract-op">determine if a site has storage access</dfn> with [=partitioned storage key=] |key| and {{Document}} |doc|, run these steps:
+To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{Document}} |doc|, run these steps:
 
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. If |flag set|'s [=has storage access flag=] is set, return true.
-1. Return false.
+1. Let |global| be |doc|'s [=relevant global object=].
+1. Return |global|'s [=environment/obtained storage access flag=].
 
-To <dfn type="abstract-op">determine the storage access policy</dfn> for [=partitioned storage key=] |key| with {{Document}} |doc| and {{Promise}} |p|, run these steps:
+To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
 
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
+1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
-1. If |permissionState| is "granted", [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. Unset |flag set|'s [=has storage access flag=].
+1. If |permissionState| is "granted":
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+        1. Set |global|'s [=environment/obtained storage access flag=] to true.
+        1. [=/Resolve=] |p|.
+    1. Return.
+1. Set |global|'s [=environment/obtained storage access flag=] to false.
 1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>
 
-Before changing the current entry of a session history, run the following steps:
+When [=snapshotting source snapshot params=]:
+1. Set [=source snapshot params/obtained storage access flag=] to |sourceDocument|'s [=source snapshot params/obtained storage access flag=].
+1. Set [=source snapshot params/environment id=] to |sourceDocument|'s [=relevant settings object=]'s [=environment/id=].
 
-1. Let |doc| be current entry's {{Document}}.
-1. Let |map| be the result of [=obtain the storage access map|obtaining the storage access map=] for |doc|'s [=Document/browsing context=]'s [=top-level browsing context=].
-1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. If |key| is failure, abort these steps.
-1. Let |flag set| be the result of [=obtain a storage access flag set|obtaining the storage access flag set=] with |key| from |map|.
-1. Unset |flag set|'s [=has storage access flag=].
+When creating |request|'s [=reserved client=] in [=create navigation params by fetching=]:
+1. Set the [=reserved client=]'s [=environment/obtained storage access flag=] to be |sourceSnapshotParams|'s [=source snapshot params/obtained storage access flag=] if:
+    1. |sourceSnapshotParams|'s [=source snapshot params/environment id=] equals <var ignore>navigable</var>'s [=active document=]'s [=relevant settings object=]'s [=environment/id=].
+    1. <var ignore>entry</var>'s URL is [=same origin=] with <var ignore>currentURL</var>.
+    1. |response| is null or |response|'s [=response/has-cross-origin-redirects=] is false.
+1. Otherwise, set |request|'s [=reserved client=]'s [=environment/obtained storage access flag=] to false.
+
+When [=set up a window environment settings object|setting up a window environment settings object=]:
+1. Set <var ignore>settings object</var>'s [=environment/obtained storage access flag=] to <var ignore>reserved environment</var>'s [=environment/obtained storage access flag=].
+
 
 ISSUE(privacycg/storage-access#3): What this section should look like ultimately hinges on
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -204,23 +204,23 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
                 1. Set |global|'s [=environment/has storage access=] to true.
                 1. [=/Resolve=] |p| with {{undefined}}.
             1. Else:
-                1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global| to [=consume user activation=] given |global|.
+                1. [=Consume user activation=] given |global|.
                 1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. If |previous permission state| is not [=permission/prompt=]:
         1. Run |process permission state| with |previous permission state|.
-        1. Return.
+        1. Abort these steps.
     1. If |has transient activation| is false:
-        1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-        1. Return.
+        1. Run |process permission state| with [=permission/denied=].
+        1. Abort these steps.
     1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
     1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
     1. If |implicitly granted| is true:
         1. Run |process permission state| with [=permission/granted=].
-        1. Return.
+        1. Abort these steps.
     1. If |implicitly denied| is true:
         1. Run |process permission state| with [=permission/denied=].
-        1. Return.
+        1. Abort these steps.
     1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
     1. Run |process permission state| with |permissionState|.
 1. Return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -182,7 +182,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
-1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |doc| is not [=allowed to use=] the `"storage-access"` [=powerful feature|feature=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -187,7 +187,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
 1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access=] is true, [=resolve=] and return |p|.
 1. [=Determine the storage access policy=] with |doc| and |p|.
 1. Return |p|.
 
@@ -204,28 +203,27 @@ To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{D
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
 
+1. Let |global| be |doc|'s [=relevant global object=].
+1. If |global|'s [=environment/has storage access=] is true, [=resolve=] |p| with {{undefined}} and return.
 1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
 1. If |previousPermissionState| is not [=permission/prompt=]:
     1. If |previousPermissionState| is [=permission/granted=]:
-        1. Set |global|'s [=environment/has storage access=] to true. Set |global|'s [=environment/has storage access=] to false.
-        1. [=/Resolve=] |p|.
+        1. Set |global|'s [=environment/has storage access=] to true.
+        1. [=/Resolve=] |p| with {{undefined}}.
         1. Return.
-    1. Set |global|'s [=environment/has storage access=] to false.
     1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Return.
-1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
-1. Let |global| be |doc|'s [=relevant global object=].
-1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
-1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
+1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with {{undefined}}, and return.
+1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
 1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
 1. If |permissionState| is "granted":
     1. [=Queue a global task=] on the [=permission task source=] given |global| to:
         1. Set |global|'s [=environment/has storage access=] to true.
-        1. [=/Resolve=] |p|.
+        1. [=/Resolve=] |p| with {{undefined}}.
     1. Return.
-1. Set |global|'s [=environment/has storage access=] to false.
 1. [=Consume user activation=] given |doc|'s {{Window}} object.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -232,7 +232,7 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for [=parti
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return |p|.
-1. Let |permissionState| be the result of [=requesting permission to use=] "storage-access".
+1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
 1. If |permissionState| is "granted", [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p|, and return.
 1. Unset |flag set|'s [=has storage access flag=].
 1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -59,6 +59,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: create navigation params by fetching; url: browsing-the-web.html#create-navigation-params-by-fetching
         text: set up a window environment settings object; url: nav-history-apis.html#set-up-a-window-environment-settings-object
         text: environment
+        text: DOM manipulation task source; url: webappapis.html#dom-manipulation-task-source
 
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     type: dfn
@@ -167,13 +168,13 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=resolve=] |p| with false and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=resolve=] |p| with false and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
-1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
-1. [=Resolve=] |p| with |global's| [=environment/has storage access=].
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=resolve=] |p| with true and return |p|.
+1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
+1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=resolve=] |p| with true and return |p|.
+1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -188,55 +189,45 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
-1. If |doc| is not [=allowed to use=] the `"storage-access"` [=powerful feature|feature=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=resolve=] and return |p|.
+1. If |doc| is not [=allowed to use=] "`storage-access`", [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
+1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. Run the following steps in parallel:
-    1. [=Determine the storage access policy=] with |doc| and |p|.
+1. If |global|'s [=environment/has storage access=] is true, [=resolve=] |p| with {{undefined}} and return.
+1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
+1. Run the following steps [=in parallel=]:
+    1. Let |process permission state| be an algorithm that, given a [=permission state=] |state|, runs the following steps:
+        1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+            1. If |state| is [=permission/granted=]:
+                1. Set |global|'s [=environment/has storage access=] to true.
+                1. [=Resolve=] |p| with {{undefined}}.
+            1. Else:
+                1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global| to [=consume user activation=] given |global|.
+                1. [=Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+    1. If |previous permission state| is not [=permission/prompt=]:
+        1. Run |process permission state| with |previous permission state|.
+        1. Return.
+    1. If |has transient activation| is false, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return.
+    1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
+    1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
+    1. If |implicitly granted| is true:
+        1. Run |process permission state| with [=permission/granted=].
+        1. Return.
+    1. If |implicitly denied| is true:
+        1. Run |process permission state| with [=permission/denied=].
+        1. Return.
+    1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
+    1. Run |process permission state| with |permissionState|.
 1. Return |p|.
+
+NOTE: The intent of this algorithm is to always require user activation before a storage-access permission will be set. Though it is within the means of user agents to set storage-access permissions based on custom heuristics without prior user activation, this specification strongly discourages such behavior, as it could lead to interoperability issues.
 
 ISSUE(privacycg/storage-access#144): We shouldn't use the permissions task source here.
 
 ISSUE: Shouldn't step 9 be [=same site=]?
-
-<h4 id="ua-policy">User Agent storage access policies</h4>
-
-Different User Agents have different policies around whether or not [=sites=] may access their [=unpartitioned data=] when they're in a [=third party context=]. User Agents check and/or modify these policies when client-side storage is accessed (see [[#storage]]) as well as when {{Document/hasStorageAccess()}} and {{Document/requestStorageAccess()}} are called.
-
-To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{Document}} |doc|, run these steps:
-
-1. Let |global| be |doc|'s [=relevant global object=].
-1. Return |global|'s [=environment/has storage access=].
-
-To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
-
-1. Let |global| be |doc|'s [=relevant global object=].
-1. If |global|'s [=environment/has storage access=] is true, [=resolve=] |p| with {{undefined}} and return.
-1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
-1. If |previousPermissionState| is not [=permission/prompt=]:
-    1. If |previousPermissionState| is [=permission/granted=]:
-        1. Set |global|'s [=environment/has storage access=] to true.
-        1. [=/Resolve=] |p| with {{undefined}}.
-        1. Return.
-    1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-    1. Return.
-1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return.
-1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
-1. If |implicitly granted| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/resolve=] |p| with {{undefined}}, and return.
-1. If |implicitly denied| is true, [=queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}, and return.
-1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
-1. If |permissionState| is "granted":
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-        1. Set |global|'s [=environment/has storage access=] to true.
-        1. [=/Resolve=] |p| with {{undefined}}.
-    1. Return.
-1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-    1. [=Consume user activation=] given |doc|'s {{Window}} object.
-    1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>
 
@@ -247,7 +238,7 @@ When [=snapshotting source snapshot params=]:
 When creating |request|'s [=reserved client=] in [=create navigation params by fetching=]:
 1. Set [=reserved client=]'s [=environment/has storage access=] to |sourceSnapshotParams|'s [=source snapshot params/has storage access=] if:
     1. |sourceSnapshotParams|'s [=source snapshot params/environment id=] equals <var ignore>navigable</var>'s [=active document=]'s [=relevant settings object=]'s [=environment/id=].
-    1. <var ignore>entry</var>'s URL is [=same origin=] with <var ignore>currentURL</var>.
+    1. <var ignore>entry</var>'s URL's [=url/origin=] is [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=].
     1. |response| is null or |response|'s [=response/has-cross-origin-redirects=] is false.
 1. Otherwise, set |request|'s [=reserved client=]'s [=environment/has storage access=] to false.
 
@@ -265,9 +256,9 @@ This API only impacts HTTP cookies. A future revision of this API might impact o
 
 <h4 id="cookies">Cookies</h4>
 
-This API is intended to be used with environments and user agent configurations that block access to unpartitioned cookies in a [=third party context=]. At the time of this writing, this concept has not yet been integrated into the [=HTTP-network-or-cache fetch=] and {{Document/cookie}} algorithms. To allow for such an integration, the [=cookie store=] will need to be modified to receive information about the top-level and embedded site of the request (to determine whether to attach cross-site, partitioned, or no cookies) as well as whether the request was made for a document that has storage access, through running the [=determine if a site has storage access=] algorithm that is defined in this specification.
+This API is intended to be used with environments and user agent configurations that block access to unpartitioned cookies in a [=third party context=]. At the time of this writing, this concept has not yet been integrated into the [=HTTP-network-or-cache fetch=] and {{Document/cookie}} algorithms. To allow for such an integration, the [=cookie store=] will need to be modified to receive information about the top-level and embedded site of the request (to determine whether to attach cross-site, partitioned, or no cookies) as well as whether the request was made for a document that has storage access, through accessing the [=environment=]'s [=environment/has storage access=] that is defined in this specification.
 
-Once the cookie store allows for receiving information about storage access, we would update [=HTTP-network-or-cache fetch=] and {{Document/cookie}} to run [=determine if a site has storage access=] and pass this information to the [=cookie store=] when retrieving cookies.
+Once the cookie store allows for receiving information about storage access, we would update [=HTTP-network-or-cache fetch=] and {{Document/cookie}} to pass the [=environment=]'s [=environment/has storage access=] to the [=cookie store=] when retrieving cookies.
 
 When getting unpartitioned cookies from the [=cookie store=] with storage access, user agents will still follow applicable `SameSite` restrictions (i.e., not attach cookies marked `SameSite=Strict` or `SameSite=Lax` in [=third party contexts=]).
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -234,8 +234,9 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Docum
         1. Set |global|'s [=environment/has storage access=] to true.
         1. [=/Resolve=] |p| with {{undefined}}.
     1. Return.
-1. [=Consume user activation=] given |doc|'s {{Window}} object.
-1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+    1. [=Consume user activation=] given |doc|'s {{Window}} object.
+    1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -167,14 +167,14 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15512 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=resolve=] |p| with false and return |p|.
+1. If |doc| is not [=Document/fully active=], then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
-1. If |global| is not a [=secure context=], then [=resolve=] |p| with false and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=resolve=] |p| with true and return |p|.
-1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=resolve=] |p| with true and return |p|.
-1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=resolve=] |p| with |global's| [=environment/has storage access=].
+1. If |global| is not a [=secure context=], then [=/resolve=] |p| with false and return |p|.
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
+1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
+1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
+1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.
 
 ISSUE: Shouldn't step 8 be [=same site=]?
@@ -186,31 +186,33 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 <!-- https://hg.mozilla.org/mozilla-central/file/tip/dom/base/Document.cpp#l15629 -->
 
 1. Let |p| be [=a new promise=].
-1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+1. If |doc| is not [=Document/fully active=], then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
-1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=resolve=] and return |p|.
-1. If |doc| is not [=allowed to use=] "`storage-access`", [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=resolve=] and return |p|.
-1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access=] is true, [=resolve=] |p| with {{undefined}} and return.
+1. If |global| is not a [=secure context=], then [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
+1. If |doc| is not [=allowed to use=] "`storage-access`", [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|. <!-- https://github.com/privacycg/storage-access/issues/40 -->
+1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
+1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
 1. Run the following steps [=in parallel=]:
     1. Let |process permission state| be an algorithm that, given a [=permission state=] |state|, runs the following steps:
         1. [=Queue a global task=] on the [=permission task source=] given |global| to:
             1. If |state| is [=permission/granted=]:
                 1. Set |global|'s [=environment/has storage access=] to true.
-                1. [=Resolve=] |p| with {{undefined}}.
+                1. [=/Resolve=] |p| with {{undefined}}.
             1. Else:
                 1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global| to [=consume user activation=] given |global|.
-                1. [=Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+                1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
     1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. If |previous permission state| is not [=permission/prompt=]:
         1. Run |process permission state| with |previous permission state|.
         1. Return.
-    1. If |has transient activation| is false, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return.
+    1. If |has transient activation| is false:
+        1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+        1. Return.
     1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
     1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
     1. If |implicitly granted| is true:
@@ -235,10 +237,13 @@ When [=snapshotting source snapshot params=]:
 1. Set [=source snapshot params/has storage access=] to |sourceDocument|'s [=source snapshot params/has storage access=].
 1. Set [=source snapshot params/environment id=] to |sourceDocument|'s [=relevant settings object=]'s [=environment/id=].
 
+To the [=create navigation params by fetching=] algorithm, insert the following step as step 3:
+1. Let |originalURL| be <var ignore>entry</var>'s URL.
+
 When creating |request|'s [=reserved client=] in [=create navigation params by fetching=]:
-1. Set [=reserved client=]'s [=environment/has storage access=] to |sourceSnapshotParams|'s [=source snapshot params/has storage access=] if:
+1. Set [=reserved client=]'s [=environment/has storage access=] to |sourceSnapshotParams|'s [=source snapshot params/has storage access=] if all of the following hold:
     1. |sourceSnapshotParams|'s [=source snapshot params/environment id=] equals <var ignore>navigable</var>'s [=active document=]'s [=relevant settings object=]'s [=environment/id=].
-    1. <var ignore>entry</var>'s URL's [=url/origin=] is [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=].
+    1. |originalURL|'s [=url/origin=] is [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=].
     1. |response| is null or |response|'s [=response/has-cross-origin-redirects=] is false.
 1. Otherwise, set |request|'s [=reserved client=]'s [=environment/has storage access=] to false.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -181,7 +181,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If this algorithm was invoked when |doc|'s {{Window}} object did not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] the `"storage-access"` permission, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
@@ -208,6 +207,12 @@ To <dfn type="abstract-op">determine if a site has storage access</dfn> with {{D
 
 To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Document}} |doc| with {{Promise}} |p|, run these steps:
 
+1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+1. If |previousPermissionState| is not [=permission/prompt=]:
+    1. Set |global|'s [=environment/obtained storage access flag=] based on whether |previousPermissionState| is [=permission/granted=] or [=permission/denied=].
+    1. [=/Resolve=] or [=/reject=] |p| (with a "{{NotAllowedError}}" {{DOMException}}) based on whether |previousPermissionState| is [=permission/granted=] or [=permission/denied=].
+    1. Return.
+1. If |doc|'s {{Window}} object does not have [=transient activation=], [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
 1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
 1. Let |global| be |doc|'s [=relevant global object=].
@@ -220,7 +225,7 @@ To <dfn type="abstract-op">determine the storage access policy</dfn> for {{Docum
         1. [=/Resolve=] |p|.
     1. Return.
 1. Set |global|'s [=environment/obtained storage access flag=] to false.
-1. If |doc|'s {{Window}} object has [=transient activation=], [=consume user activation=] with it.
+1. [=Consume user activation=] given |doc|'s {{Window}} object.
 1. [=Queue a global task=] on the [=permission task source=] given |global| to [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
 
 <h3 id="navigation">Changes to navigation</h3>

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -273,22 +273,22 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 
 <h2 id="permissions-integration">Permissions Integration</h2>
 
-The Storage Access API defines a [=powerful feature=] identified by the [=powerful feature/name=] `"storage-access"`.
+The Storage Access API defines a [=powerful feature=] identified by the [=powerful feature/name=] "<dfn export permission><code>storage-access</code></dfn>".
 
 <h3 id="permissions-key-generate">Changes to generate a permission store key</h3>
 
 Update the generate a permission store key algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
 
-1. If |name| is "storage-access", run the following steps:
-    1. Let |topLevelOrigin| be |settings|' [=environment/top-level origin].
-    1. Let |embeddedOrigin| be |settings|' [=environment/origin].
+1. If |name| is "<a permission><code>storage-access</code></a>", run the following steps:
+    1. Let |topLevelOrigin| be |settings|' [=top-level origin=].
+    1. Let |embeddedOrigin| be |settings|' [=environment settings object/origin=].
     1. Return (|topLevelOrigin|, |embeddedOrigin|).
 
 <h3 id="permissions-key-compare">Changes to compare permission store keys</h3>
 
 Update the compare permission store keys algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
 
-1. If |name| is "storage-access", run the following steps:
+1. If |name| is "<a permission><code>storage-access</code></a>", run the following steps:
     1. Let |topLevelSite1| be the result of [=obtaining a site=] from |key1|'s permission store key/top-level origin.
     1. Let |topLevelSite2| be the result of [=obtaining a site=] from |key2|'s permission store key/top-level origin.
     1. If |topLevelSite1| is not [=same site=] with |topLevelSite2|, return false.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -273,27 +273,35 @@ To the [=parse a sandboxing directive=] algorithm, add the following under step 
 
 <h2 id="permissions-integration">Permissions Integration</h2>
 
-The Storage Access API defines a [=powerful feature=] identified by the [=powerful feature/name=] "<dfn export permission><code>storage-access</code></dfn>".
+The Storage Access API defines a [=powerful feature=] identified by the [=powerful feature/name=] "<dfn export permission><code>storage-access</code></dfn>". It defines the following permission-related algorithms:
 
-<h3 id="permissions-key-generate">Changes to generate a permission store key</h3>
+<dl>
+  <dt>[=powerful feature/permission query algorithm=]</dt>
+  <dd>
+    To query the "<a permission><code>storage-access</code></a>" permission, given a {{PermissionDescriptor}} |permissionDesc| and a {{PermissionStatus}} |status|, run the following steps:
 
-Update the generate a permission store key algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
+    1. Set |status|'s {{PermissionStatus/state}} to |permissionDesc|'s [=permission state=].
+    1. If |status|'s {{PermissionStatus/state}} is [=permission/denied=], set |status|'s {{PermissionStatus/state}} to [=permission/prompt=].
 
-1. If |name| is "<a permission><code>storage-access</code></a>", run the following steps:
-    1. Let |topLevelOrigin| be |settings|' [=top-level origin=].
+        Note: The "denied" permission state is not revealed to avoid exposing the user's decision to developers. This is done to prevent retaliation against the user and repeated prompting to the detriment of the user experience.
+  </dd>
+  <dt>[=powerful feature/permission key generation algorithm]</dt>
+  <dd>
+    To generate a new [=permission store key] for the "<a permission><code>storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
+
+    1. Let |topLevelSite| be |settings|' [=top-level site=].
     1. Let |embeddedOrigin| be |settings|' [=environment settings object/origin=].
-    1. Return (|topLevelOrigin|, |embeddedOrigin|).
+    1. Return (|topLevelSite|, |embeddedOrigin|).
+  </dd>
+  <dt>[=powerful feature/permission key comparison algorithm]</dt>
+  <dd>
+    To compare the [=permission keys] |key1| and |key2| for the "<a permission><code>storage-access</code></a>" feature, run the following steps:
 
-<h3 id="permissions-key-compare">Changes to compare permission store keys</h3>
-
-Update the compare permission store keys algorithm to take the [=powerful feature/name=] |name|. Prepend the following steps to it:
-
-1. If |name| is "<a permission><code>storage-access</code></a>", run the following steps:
-    1. Let |topLevelSite1| be the result of [=obtaining a site=] from |key1|'s permission store key/top-level origin.
-    1. Let |topLevelSite2| be the result of [=obtaining a site=] from |key2|'s permission store key/top-level origin.
-    1. If |topLevelSite1| is not [=same site=] with |topLevelSite2|, return false.
-    1. If |key1|'s permission store key/granted origin is not [=same origin=] with |key2|'s permission store key/granted origin, return false.
+    1. If |key1|[0] is not [=same site=] with |key2|[0], return false.
+    1. If |key1|[1] is not [=same origin=] with |key2|[1], return false.
     1. Return true.
+  </dd>
+</dl>
 
 <h2 id="permissions-policy-integration">Permissions Policy Integration</h2>
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -194,7 +194,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. [=Queue a global task=] on the [=permission task source=] given |global| to resolve or reject |p| based on the result of |hasAccess|.
 1. Return |p|.
 
-ISSUE: Shouldn't step 10 be [=same site=]?
+ISSUE: Shouldn't step 9 be [=same site=]?
 
 <h4 id="ua-policy">User Agent storage access policies</h4>
 


### PR DESCRIPTION
This is an attempt to migrate to a "per-frame" model, as discussed in https://github.com/privacycg/storage-access/issues/122. This is built on top of #138 as a starting point.

The approach is to define a flag that lives on environment, and is set by `document.requestStorageAccess` and read by `document.hasStorageAccess`. In order to propagate storage access during self-initiated, same-origin navigations, we also add a flag to the `source snapshot params` used during `create navigation params by fetching`, and conditionally copy the `sourceDocument`'s relevant settings object's flag over to the new environment that will be created. This should let us achieve the benefits of the BrowsingContext approach discussed in #122, without having to add and clear state in BrowsingContext.


Leaving the checklist for now, though I'd like to get some feedback before I try to write WPTs:
- [x] At least two implementers are interested (and none opposed)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://crrev.com/c/4117243 
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1401089
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1805861
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=249382

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/storage-access/pull/141.html" title="Last updated on Jan 17, 2023, 2:03 AM UTC (f1ad74a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/141/a20c3cc...cfredric:f1ad74a.html" title="Last updated on Jan 17, 2023, 2:03 AM UTC (f1ad74a)">Diff</a>