### PR TITLE
Editorial: Remove partitioned storage key and implementation-defined steps

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -135,22 +135,6 @@ Modify the definition of [=source snapshot params=] in the following manner:
 1. Add a new member called <dfn for="source snapshot params">has storage access</dfn> of type [=boolean=].
 1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque [=string=].
 
-A <dfn>partitioned storage key</dfn> is a [=tuple=] consisting of a <dfn for="partitioned storage key">top-level site</dfn> (a [=site=]) and an <dfn for="partitioned storage key">embedded origin</dfn> (an [=/origin=]).
-
-<div class=example>
-
-`(("https", "news.example"), ("https", "social.example", null, null))` is a [=partitioned storage key=] whose [=top-level site=] is `("https", "news.example")` and whose [=embedded origin=] is `("https", "social.example", null, null)`.
-
-</div>
-
-To <dfn type="abstract-op">generate a partitioned storage key</dfn> for a {{Document}} |doc|, run the following steps:
-
-1. Let |settings| be |doc|'s [=relevant settings object=].
-1. Let |site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], return the [=partitioned storage key=] (|site|, |site|).
-1. Let |top-level site| be the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
-1. Return the [=partitioned storage key=] (|top-level site|, |site|).
-
 <h3 id="the-document-object">Changes to {{Document}}</h3>
 
 <pre class="idl">
@@ -209,15 +193,10 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. If |has transient activation| is false:
         1. Run |process permission state| with [=permission/denied=].
         1. Abort these steps.
-    1. Let |key| be the result of [=generate a partitioned storage key|generating a partitioned storage key=] from |doc|.
-    1. Let |implicitly granted| and |implicitly denied| (each a [=boolean=]) be the result of running an [=implementation-defined=] set of steps to determine if |key|'s [=partitioned storage key/embedded origin=]'s request for storage access on |key|'s [=partitioned storage key/top-level site=] should be granted or denied without prompting the user.
-    1. If |implicitly granted| is true:
-        1. Run |process permission state| with [=permission/granted=].
-        1. Abort these steps.
-    1. If |implicitly denied| is true:
-        1. Run |process permission state| with [=permission/denied=].
-        1. Abort these steps.
     1. Let |permissionState| be the result of [=requesting permission to use=] "<a permission><code>storage-access</code></a>".
+
+    NOTE: Note that when requesting permissions and deciding whether to show a prompt, user agents apply implementation-defined behavior to shape the end user experience. Particularly for `storage-access`, user agents are known to apply custom rules that will grant or deny a permission without showing a prompt.
+
     1. Run |process permission state| with |permissionState|.
 1. Return |p|.
 
@@ -288,13 +267,19 @@ The Storage Access API defines a [=powerful feature=] identified by the [=powerf
   <dd>
     A [=permission key=] of the "<a permission><code>storage-access</code></a>" feature is a [=tuple=] consisting of a [=site=] <dfn for="permission key">top-level</dfn> and an [=/origin=] <dfn for="permission key">requester</dfn>.
 
+<div class=example>
+
+`(("https", "news.example"), ("https", "social.example", null, null))` is a [=permission key=] whose [=permission key/top-level=] is `("https", "news.example")` and whose [=permission key/requester=] is `("https", "social.example", null, null)`.
+
+</div>
+
     ISSUE(privacycg/storage-access#147): Note that this will likely change to a (site, site) keying.
   </dd>
   <dt>[=powerful feature/permission key generation algorithm=]</dt>
   <dd>
     To generate a new [=permission key=] for the "<a permission><code>storage-access</code></a>" feature, given an [=environment settings object=] |settings|, run the following steps:
 
-    1. Let |topLevelSite| be |settings|' [=top-level site=].
+    1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment/top-level origin=].
     1. Let |embeddedOrigin| be |settings|' [=environment settings object/origin=].
     1. Return (|topLevelSite|, |embeddedOrigin|).
   </dd>


### PR DESCRIPTION
(closes #156)

This was originally part of #159 but I'm submitting it separately since this is a rather editorial change that we can probably fast-track without including it in the other PR which still needs WPT etc.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/storage-access/pull/161.html" title="Last updated on Jan 26, 2023, 5:26 PM UTC (a86a871)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/161/ab80b38...johannhof:a86a871.html" title="Last updated on Jan 26, 2023, 5:26 PM UTC (a86a871)">Diff</a>