### PR TITLE
Specify behavior in A > * > A scenarios

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -160,7 +160,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 
-ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). For the purpose of implementation, the user agent should use this step to determine whether the embedded document does not need to invoke {{Document/requestStorageAccess()}} to be granted storage access. This may involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
+ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). For the purpose of implementation, the user agent should use this step to determine whether the embedded document needs to invoke {{Document/requestStorageAccess()}} to be granted storage access. This might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
 1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.
@@ -184,7 +184,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. Set |global|'s [=environment/has storage access=] to true.
     1. [=/Resolve=] and return |p|.
 
-NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess` to opt into storage access in scenarios where it might have have been restricted by default for security (not privacy) purposes.
+  NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess` to opt into storage access in scenarios where it might have have been restricted by default for security (not privacy) purposes.
 
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -184,7 +184,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. Set |global|'s [=environment/has storage access=] to true.
     1. [=/Resolve=] and return |p|.
 
-  NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess` to opt into storage access in scenarios where it might have have been restricted by default for security (not privacy) purposes.
+  NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
 
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -158,7 +158,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |global| is not a [=secure context=], then [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
-1. If |doc|'s [=Document/browsing context=] is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
+1. If |doc| is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true and return |p|.
 
   ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
@@ -178,9 +178,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |doc| is not [=allowed to use=] "`storage-access`", [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |settings|'s [=top-level origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
-1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
-1. If |embeddedSite| is [=same site=] with |topLevelSite|:
+1. If |settings|'s [=top-level origin=] is [=same site=] with |settings|'s [=environment settings object/origin=]:
     1. Set |global|'s [=environment/has storage access=] to true.
     1. [=/Resolve=] and return |p|.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -183,6 +183,9 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. If |embeddedSite| is [=same site=] with |topLevelSite|:
     1. Set |global|'s [=environment/has storage access=] to true.
     1. [=/Resolve=] and return |p|.
+
+NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess` to opt into storage access in scenarios where it might have have been restricted by default for security (not privacy) purposes.
+
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -160,7 +160,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 
-ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). For the purpose of implementation, the user agent should use this step to determine whether the embedded document needs to invoke {{Document/requestStorageAccess()}} to be granted storage access. This might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
+  ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
 1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -34,6 +34,9 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
 spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265
     type: dfn
         text: cookie store; url: section-5.3
+spec: RFC6265bis; urlPrefix: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-11
+    type: dfn
+        text: site for cookies; url: section-5.2.1
 urlPrefix: https://w3c.github.io/permissions/; spec: permissions
     text: permissions task source; url: #permissions-task-source; type: dfn
 urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#; spec: webdriver
@@ -155,11 +158,12 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |global| is not a [=secure context=], then [=/resolve=] |p| with false and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] |p| with true and return |p|.
+1. If |doc|'s [=Document/browsing context=] is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
+
+ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). For the purpose of implementation, the user agent should use this step to determine whether the embedded document does not need to invoke {{Document/requestStorageAccess()}} to be granted storage access. This may involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
+
 1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |global's| [=environment/has storage access=].
 1. Return |p|.
-
-ISSUE: Shouldn't step 8 be [=same site=]?
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:
 
@@ -168,12 +172,17 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
+1. Let |settings| be |doc|'s [=relevant settings object=].
 1. If |global| is not a [=secure context=], then [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] "`storage-access`", [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/origin=] is [=same origin=] with the [=top-level origin=] of |doc|'s [=relevant settings object=], [=/resolve=] and return |p|.
+1. If |settings|'s [=top-level origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
+1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=top-level origin=].
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |settings|' [=environment settings object/origin=].
+1. If |embeddedSite| is [=same site=] with |topLevelSite|:
+    1. Set |global|'s [=environment/has storage access=] to true.
+    1. [=/Resolve=] and return |p|.
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
@@ -203,8 +212,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 NOTE: The intent of this algorithm is to always require user activation before a storage-access permission will be set. Though it is within the means of user agents to set storage-access permissions based on custom heuristics without prior user activation, this specification strongly discourages such behavior, as it could lead to interoperability issues.
 
 ISSUE(privacycg/storage-access#144): We shouldn't use the permissions task source here.
-
-ISSUE: Shouldn't step 9 be [=same site=]?
 
 <h3 id="navigation">Changes to navigation</h3>
 


### PR DESCRIPTION
This commit tries to make rSA and hSA match the reality of cookie blocking browsers perform in edge cases such as A > A and A > B > A. I think all browsers perform a same site check, so moving away from same origin makes sense. Additionally, Chrome will block cookies based on the "site for cookies" whereas Firefox and Safari don't. We plan to discuss this behavior separately and can hopefully align eventually.

As discussed with the other editors, we agree that it still makes sense from a privacy perspective to automatically grant storage access in a same site scenario, since the "site for cookies" check is for security only. This could previously lead to inconsistencies in browsers that block cookies based on "site for cookies", as hSA would return true and rSA would resolve automatically without storage access ever being granted in an ABA case. This commit fixes that by explicitly setting the "has storage access" bit after a successful same-site check in rSA.

I'm referencing the in-progress "authority" concept on advice of @annevk.

<!--
Thank you for contributing to The Storage Access API! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed): N/A, this is matching current behavior
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/4340989
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1420320
   * Gecko: N/A
   * WebKit: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/storage-access/pull/169.html" title="Last updated on May 10, 2023, 10:00 AM UTC (f85c618)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/169/17ff4fd...johannhof:f85c618.html" title="Last updated on May 10, 2023, 10:00 AM UTC (f85c618)">Diff</a>