### PR TITLE
Let `document.hasStorageAccess` check whether the Document already has unpartitioned data access

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -169,7 +169,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         
         Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
-        1. If user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
+        1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
         1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
         1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -129,8 +129,6 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
-<dfn>Global user settings</dfn> are user agent settings that can be modified by users.
-
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
 Modify the definition of [=environment=] in the following manner:
@@ -164,9 +162,14 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
-1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with true and return |p|.
+1. Let |hasStorageAccess| be |global|'s [=environment/has storage access=].
 1. Run the following steps [=in parallel=]:
-    1. Let |has unpartitioned data access| be the result of whether the user agent allows |doc| access [=unpartitioned data=] based on [=global user settings=].
+    1. Let <dfn>whether the user agent allows [=unpartitioned data=] access</dfn> be an algorithm that, given a [=boolean=] |has per-frame storage access|, runs the following steps:
+        1. If |has per-frame storage access| is false:
+            1. If user agent allows [=unpartitioned data=] access via settings, return true.
+        1. If user agent disallows [=unpartitioned data=] access via settings, return false.
+        1. Return true.
+    1. Let |has unpartitioned data access| be the result of running <a href="#whether-the-user-agent-allows-unpartitioned-data-access">whether the user agent allows unpartitioned data access</a> with |hasStorageAccess|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |has unpartitioned data access|.
 1. Return |p|.
 
@@ -190,7 +193,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
         NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
 
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] and return |p|.
+1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
 1. Run the following steps [=in parallel=]:
     1. Let |process permission state| be an algorithm that, given a [=permission state=] |state|, runs the following steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -129,6 +129,8 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
+<dfn>Global user settings</dfn> are user agent settings that can be modified by users.
+
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
 Modify the definition of [=environment=] in the following manner:
@@ -162,7 +164,10 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
-1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with true and return |p|.
+1. Run the following steps [=in parallel=]:
+    1. Let |has unpartitioned data access| be the result of whether the user agent allows |doc| access [=unpartitioned data=] based on [=global user settings=].
+    1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |has unpartitioned data access|.
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:
@@ -185,7 +190,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
         NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
 
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
+1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] and return |p|.
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
 1. Run the following steps [=in parallel=]:
     1. Let |process permission state| be an algorithm that, given a [=permission state=] |state|, runs the following steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -165,21 +165,21 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
+    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
         
         Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
-        1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
-        1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
-        1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
+        1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "`none`".
+        1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
+        1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "`disallow`".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
-        1. If |explicitSetting| is "none" and |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+        1. If |explicitSetting| is "`none`" and |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
                 Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 
-        1. If |explicitSetting| is "allow", [=/resolve=] |p| with true.
+        1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
         1. [=/Resolve=] |p| with false.
 1. Return |p|.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -178,7 +178,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         1. If |explicitSetting| is "none":
             1. If |previousPermissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
                 
-                Note: The user decission to revoke the previously granted permission should overrule the cookie access without pending a reload on the iframe or similar.
+                Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 
         1. If |explicitSetting| is "allow", [=/resolve=] |p| with true and return |p|.
         1. [=/Resolve=] |p| with false and return |p|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -167,7 +167,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Run the following steps [=in parallel=]:
     1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
         
-        Note: The "explicit allow" can come from user agent's per-site allow-lists or the user changing global browser settings, etc..
+        Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
         1. If user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
         1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -163,14 +163,14 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
 1. Run the following steps [=in parallel=]:
-    1. Let <dfn>whether the user agent allows unpartitioned cookie access</dfn> be an algorithm that, given a user agent's settings object |user agent settings| and a [=boolean=] |has per-frame storage access|, runs the following steps:
+    1. Let |Whether the User Agent Allows Unpartitioned Cookie Access| be an algorithm that, given a user agent's settings object |user agent settings|, runs the following steps:
         1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-            1. If |has per-frame storage access| is false:
+            1. If |global|'s [=environment/has storage access=] is false:
                 1. If |user agent settings| allows unpartitioned cookie access, [=/resolve=] |p| with true and return |p|.
             1. If |user agent settings| disallows unpartitioned cookie access, [=/resolve=] |p| with false and return |p|.
             1. [=/Resolve=] |p| with true and return |p|.
     1. Let |user agent settings| be user agent's settings.
-    1. Run <a href="#whether-the-user-agent-allows-unpartitioned-cookie-access">whether the user agent allows unpartitioned cookie access</a> with |user agent settings| and |global|'s [=environment/has storage access=].
+    1. Run |Whether the User Agent Allows Unpartitioned Cookie Access| with |user agent settings|.
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -165,12 +165,12 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |hasStorageAccess| be |global|'s [=environment/has storage access=].
 1. Run the following steps [=in parallel=]:
     1. Let <dfn>whether the user agent allows [=unpartitioned data=] access</dfn> be an algorithm that, given a [=boolean=] |has per-frame storage access|, runs the following steps:
-        1. If |has per-frame storage access| is false:
-            1. If user agent allows [=unpartitioned data=] access via settings, return true.
-        1. If user agent disallows [=unpartitioned data=] access via settings, return false.
-        1. Return true.
-    1. Let |has unpartitioned data access| be the result of running <a href="#whether-the-user-agent-allows-unpartitioned-data-access">whether the user agent allows unpartitioned data access</a> with |hasStorageAccess|.
-    1. [=Queue a global task=] on the [=permissions task source=] given |global| to [=/resolve=] |p| with |has unpartitioned data access|.
+        1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+            1. If |has per-frame storage access| is false:
+                1. If user agent allows [=unpartitioned data=] access via settings, [=/resolve=] |p| with true and return |p|.
+            1. If user agent disallows [=unpartitioned data=] access via settings, [=/resolve=] |p| with false and return |p|.
+            1. [=/Resolve=] |p| with true and return |p|.
+    1. Run <a href="#whether-the-user-agent-allows-unpartitioned-data-access">whether the user agent allows unpartitioned data access</a> with |hasStorageAccess|.
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -170,7 +170,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
         1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
-        1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
+        1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
         1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -161,7 +161,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
+    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of two [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
         
         Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
@@ -169,7 +169,6 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
         1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "`disallow`".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
-    1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
         1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
         1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
@@ -179,6 +178,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
                 ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
             
+            1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
             1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
                 Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -156,12 +156,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=/resolve=] |p| with false and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] |p| with true and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
-1. If |doc| is same authority with |doc|'s [=Document/browsing context=]'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true and return |p|.
-
-    ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
-
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -157,6 +157,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=/resolve=] |p| with false and return |p|.
 1. If the [=top-level origin=] of |doc|'s [=relevant settings object=] is an [=opaque origin=], [=/resolve=] |p| with false and return |p|.
+1. Let |browsingContext| be |doc|'s [=Document/browsing context=].
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
@@ -170,11 +171,18 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
-        1. If |explicitSetting| is "`none`" and |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+        1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
+        1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
+        1. If |explicitSetting| is "`none`":
+            1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true.
+            1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true.
+
+                ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
+            
+            1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
                 Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 
-        1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
         1. [=/Resolve=] |p| with false.
 1. Return |p|.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -163,14 +163,20 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
 1. Run the following steps [=in parallel=]:
-    1. Let |Whether the User Agent Allows Unpartitioned Cookie Access| be an algorithm that, given a user agent's settings object |user agent settings|, runs the following steps:
-        1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-            1. If |global|'s [=environment/has storage access=] is false:
-                1. If |user agent settings| allows unpartitioned cookie access, [=/resolve=] |p| with true and return |p|.
-            1. If |user agent settings| disallows unpartitioned cookie access, [=/resolve=] |p| with false and return |p|.
-            1. [=/Resolve=] |p| with true and return |p|.
-    1. Let |user agent settings| be user agent's settings.
-    1. Run |Whether the User Agent Allows Unpartitioned Cookie Access| with |user agent settings|.
+    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm that runs the following steps:
+        
+        Note: The "explicit allow" can come from user agent's per-site allow-lists or the user changing global browser settings, etc..
+        
+        1. If user agent does not have explicit settings for unpartitioned cookie access for |doc|, return 'none'.
+        1. If user agent's settings explicitly allow unpartitioned cookie access for |doc|, return 'allow'.
+        1. If user agent's settings explicitly disallow unpartitioned cookie access for |doc|, return 'disallow'.
+    1. Let |explicitSetting| be the result of |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access|.
+    1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+    1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+        1. If |explicitSetting| is 'none':
+            1. If |previous permission state| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
+        1. If |explicitSetting| is 'allow', [=/resolve=] |p| with true and return |p|.
+        1. [=/Resolve=] |p| with false and return |p|.
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -165,7 +165,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
+    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
         
         Note: The "explicit allow" can come from user agent's per-site allow-lists or the user changing global browser settings, etc..
         

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -173,15 +173,15 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
         1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
-    1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+    1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
         1. If |explicitSetting| is "none":
-            1. If |previousPermissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
+            1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
                 Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 
-        1. If |explicitSetting| is "allow", [=/resolve=] |p| with true and return |p|.
-        1. [=/Resolve=] |p| with false and return |p|.
+        1. If |explicitSetting| is "allow", [=/resolve=] |p| with true.
+        1. [=/Resolve=] |p| with false.
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -171,7 +171,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         
         1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
         1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
-        1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
+        1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -175,8 +175,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
-        1. If |explicitSetting| is "none":
-            1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+        1. If |explicitSetting| is "none" and |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
                 Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -162,20 +162,22 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
+1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm that runs the following steps:
+    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
         
         Note: The "explicit allow" can come from user agent's per-site allow-lists or the user changing global browser settings, etc..
         
-        1. If user agent does not have explicit settings for unpartitioned cookie access for |doc|, return 'none'.
-        1. If user agent's settings explicitly allow unpartitioned cookie access for |doc|, return 'allow'.
-        1. If user agent's settings explicitly disallow unpartitioned cookie access for |doc|, return 'disallow'.
-    1. Let |explicitSetting| be the result of |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access|.
-    1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+        1. If user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
+        1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
+        1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
+    1. Let |explicitSetting| be the result of |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| with (|topLevelSite|, |embeddedSite|).
+    1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to:
-        1. If |explicitSetting| is 'none':
-            1. If |previous permission state| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
-        1. If |explicitSetting| is 'allow', [=/resolve=] |p| with true and return |p|.
+        1. If |explicitSetting| is "none":
+            1. If |previousPermissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
+        1. If |explicitSetting| is "allow", [=/resolve=] |p| with true and return |p|.
         1. [=/Resolve=] |p| with false and return |p|.
 1. Return |p|.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -162,15 +162,15 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
     ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
 
-1. Let |hasStorageAccess| be |global|'s [=environment/has storage access=].
 1. Run the following steps [=in parallel=]:
-    1. Let <dfn>whether the user agent allows [=unpartitioned data=] access</dfn> be an algorithm that, given a [=boolean=] |has per-frame storage access|, runs the following steps:
+    1. Let <dfn>whether the user agent allows unpartitioned cookie access</dfn> be an algorithm that, given a user agent's settings object |user agent settings| and a [=boolean=] |has per-frame storage access|, runs the following steps:
         1. [=Queue a global task=] on the [=permission task source=] given |global| to:
             1. If |has per-frame storage access| is false:
-                1. If user agent allows [=unpartitioned data=] access via settings, [=/resolve=] |p| with true and return |p|.
-            1. If user agent disallows [=unpartitioned data=] access via settings, [=/resolve=] |p| with false and return |p|.
+                1. If |user agent settings| allows unpartitioned cookie access, [=/resolve=] |p| with true and return |p|.
+            1. If |user agent settings| disallows unpartitioned cookie access, [=/resolve=] |p| with false and return |p|.
             1. [=/Resolve=] |p| with true and return |p|.
-    1. Run <a href="#whether-the-user-agent-allows-unpartitioned-data-access">whether the user agent allows unpartitioned data access</a> with |hasStorageAccess|.
+    1. Let |user agent settings| be user agent's settings.
+    1. Run <a href="#whether-the-user-agent-allows-unpartitioned-cookie-access">whether the user agent allows unpartitioned cookie access</a> with |user agent settings| and |global|'s [=environment/has storage access=].
 1. Return |p|.
 
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -172,7 +172,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         1. If user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
         1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
         1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
-    1. Let |explicitSetting| be the result of |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| with (|topLevelSite|, |embeddedSite|).
+    1. Let |explicitSetting| be the result of determining |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| with (|topLevelSite|, |embeddedSite|).
     1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=permission task source=] given |global| to:
         1. If |explicitSetting| is "none":

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -165,18 +165,21 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
+    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of [=sites=], runs the following steps. This algorithm returns "none", "allow" or "disallow".
         
         Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
         1. If user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "none".
         1. If user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "allow".
         1. If user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "disallow".
-    1. Let |explicitSetting| be the result of determining |Whether the User Agent Explicitly Allows Unpartitioned Cookie Access| with (|topLevelSite|, |embeddedSite|).
+    1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
     1. Let |previousPermissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
-    1. [=Queue a global task=] on the [=permission task source=] given |global| to:
+    1. [=Queue a global task=] on the [=permissions task source=] given |global| to:
         1. If |explicitSetting| is "none":
             1. If |previousPermissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and return |p|.
+                
+                Note: The user decission to revoke the previously granted permission should overrule the cookie access without pending a reload on the iframe or similar.
+
         1. If |explicitSetting| is "allow", [=/resolve=] |p| with true and return |p|.
         1. [=/Resolve=] |p| with false and return |p|.
 1. Return |p|.


### PR DESCRIPTION
<!--
Thank you for contributing to The Storage Access API! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

This commits tries to make hSA match the description in the spec that “This specification defines a method to query whether or not a [Document](https://dom.spec.whatwg.org/#document) currently has access to its [unpartitioned data](https://privacycg.github.io/storage-access/#unpartitioned-data) ([hasStorageAccess()](https://privacycg.github.io/storage-access/#dom-document-hasstorageaccess)) …” by including a check of whether the user agent allows the `document` to access unpartitioned data based on user settings.

- [x] At least two implementers are interested (and none opposed)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/4611289
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1433013
   * Gecko: N/A
   * WebKit: N/A

Fixes https://github.com/privacycg/storage-access/issues/171

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shuranhuang/storage-access/pull/174.html" title="Last updated on Jul 25, 2023, 2:30 PM UTC (024f4b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/174/69042e6...shuranhuang:024f4b8.html" title="Last updated on Jul 25, 2023, 2:30 PM UTC (024f4b8)">Diff</a>