### PR TITLE
document.requestStorageAccess should consider user explicit settings for unpartitioned data access

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -192,18 +192,13 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Let |global| be |doc|'s [=relevant global object=].
 1. Let |settings| be |doc|'s [=relevant settings object=].
 1. If |global| is not a [=secure context=], then [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |doc|'s [=Document/browsing context=] is a [=top-level browsing context=], [=/resolve=] and return |p|.
 1. If |doc| is not [=allowed to use=] "`storage-access`", [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |doc|'s [=Document/origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |settings|'s [=top-level origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |settings|'s [=top-level origin=] is [=same site=] with |settings|'s [=environment settings object/origin=]:
-    1. Set |global|'s [=environment/has storage access=] to true.
-    1. [=/Resolve=] and return |p|.
-
-       NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
-
+1. If |settings|'s [=top-level origin=] is an [=opaque origin=], [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.    
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.
+1. Let |browsingContext| be |doc|'s [=Document/browsing context=].
+1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
+1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Let |has transient activation| be whether |doc|'s {{Window}} object has [=transient activation=].
 1. Run the following steps [=in parallel=]:
     1. Let |process permission state| be an algorithm that, given a [=permission state=] |state|, runs the following steps:
@@ -214,6 +209,23 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
             1. Else:
                 1. [=Consume user activation=] given |global|.
                 1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
+    1. Let |explicitSetting| be the result of determining <a abstract-op>whether the user agent explicitly allows unpartitioned cookie access</a> with (|topLevelSite|, |embeddedSite|).
+    1. If |explicitSetting| is "`disallow`":
+        1. Run |process permission state| with [=permission/denied=].
+        1. Abort these steps.
+    1. If |explicitSetting| is "`allow`":
+        1. Run |process permission state| with [=permission/granted=].
+        1. Abort these steps.
+    1. If |explicitSetting| is "`none`":
+        1. If |browsingContext| is a [=top-level browsing context=]:
+            1. Run |process permission state| with [=permission/granted=].
+            1. Abort these steps.
+        1. If |embeddedSite| is [=same site=] with |topLevelSite|:
+            
+            NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
+
+            1. Run |process permission state| with [=permission/granted=].
+            1. Abort these steps.
     1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. If |previous permission state| is not [=permission/prompt=]:
         1. Run |process permission state| with |previous permission state|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -132,7 +132,8 @@ To <dfn>determine whether the user agent explicitly allows unpartitioned cookie 
         
     1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "`none`".
     1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
-    1. Assert: the user agent's settings explicitly disallow unpartitioned cookie access for |tuple| and return "`disallow`".
+    1. [=Assert=]: the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|.
+    1. Return "`disallow`".
 
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
@@ -167,18 +168,19 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
     1. Let |explicitSetting| be the result of [=determine whether the user agent explicitly allows unpartitioned cookie access|determining whether the user agent explicitly allows unpartitioned cookie access=] with (|topLevelSite|, |embeddedSite|).
+    1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=networking task source=] given |global| to:
         1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
         1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
-        1. Assert: |explicitSetting| is "`none`":
-            1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true.
-            1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true.
+        1. [=Assert=]: |explicitSetting| is "`none`".
+        1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true.
+        1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true.
 
-                ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
-
-            1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
-
-                Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
+            ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=same site=] check with the top-level document.
+            
+        1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+                
+            Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 
         1. [=/Resolve=] |p| with false.
 1. Return |p|.
@@ -216,16 +218,16 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. If |explicitSetting| is "`allow`":
         1. Run |process permission state| with [=permission/granted=].
         1. Abort these steps.
-    1. Assert: |explicitSetting| is "`none`":
-        1. If |browsingContext| is a [=top-level browsing context=]:
-            1. Run |process permission state| with [=permission/granted=].
-            1. Abort these steps.
-        1. If |embeddedSite| is [=same site=] with |topLevelSite|:
+    1. [=Assert=]: |explicitSetting| is "`none`".
+    1. If |browsingContext| is a [=top-level browsing context=]:
+        1. Run |process permission state| with [=permission/granted=].
+        1. Abort these steps.
+    1. If |embeddedSite| is [=same site=] with |topLevelSite|:
             
-            NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
+        NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
 
-            1. Run |process permission state| with [=permission/granted=].
-            1. Abort these steps.
+        1. Run |process permission state| with [=permission/granted=].
+        1. Abort these steps.
     1. Let |previous permission state| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. If |previous permission state| is not [=permission/prompt=]:
         1. Run |process permission state| with |previous permission state|.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -132,7 +132,7 @@ To <dfn>determine whether the user agent explicitly allows unpartitioned cookie 
         
     1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "`none`".
     1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
-    1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "`disallow`".
+    1. Assert: the user agent's settings explicitly disallow unpartitioned cookie access for |tuple| and return "`disallow`".
 
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
@@ -170,7 +170,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     1. [=Queue a global task=] on the [=networking task source=] given |global| to:
         1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
         1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
-        1. If |explicitSetting| is "`none`":
+        1. Assert: |explicitSetting| is "`none`":
             1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true.
             1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true.
 
@@ -216,7 +216,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. If |explicitSetting| is "`allow`":
         1. Run |process permission state| with [=permission/granted=].
         1. Abort these steps.
-    1. If |explicitSetting| is "`none`":
+    1. Assert: |explicitSetting| is "`none`":
         1. If |browsingContext| is a [=top-level browsing context=]:
             1. Run |process permission state| with [=permission/granted=].
             1. Abort these steps.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -126,6 +126,14 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
+Let <dfn export abstract-op>whether the user agent explicitly allows unpartitioned cookie access</dfn> be an algorithm that, given a [=tuple=] |tuple| consisting of two [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
+        
+    Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
+        
+    1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "`none`".
+    1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
+    1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "`disallow`".
+
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
 Modify the definition of [=environment=] in the following manner:
@@ -158,15 +166,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |whether the user agent explicitly allows unpartitioned cookie access| be an algorithm that, given a [=tuple=] |tuple| consisting of two [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
-
-        Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
-
-        1. If the user agent does not have explicit settings for unpartitioned cookie access for |tuple|, return "`none`".
-        1. If the user agent's settings explicitly allow unpartitioned cookie access for |tuple|, return "`allow`".
-        1. If the user agent's settings explicitly disallow unpartitioned cookie access for |tuple|, return "`disallow`".
-    1. Let |explicitSetting| be the result of determining |whether the user agent explicitly allows unpartitioned cookie access| with (|topLevelSite|, |embeddedSite|).
-    1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
+    1. Let |explicitSetting| be the result of determining <a abstract-op>whether the user agent explicitly allows unpartitioned cookie access</a> with (|topLevelSite|, |embeddedSite|).
     1. [=Queue a global task=] on the [=networking task source=] given |global| to:
         1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
         1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
@@ -200,7 +200,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
     1. Set |global|'s [=environment/has storage access=] to true.
     1. [=/Resolve=] and return |p|.
 
-        NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
+       NOTE: This check is [=same site=] on purpose, to allow embedded sites to use `requestStorageAccess()` to opt into storage access without involvement from the end user in scenarios where storage access is restricted for security and not privacy purposes.
 
 1. If |doc|'s [=active sandboxing flag set=] has its [=sandbox storage access by user activation flag=] set, [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |global|'s [=environment/has storage access=] is true, [=/resolve=] |p| with {{undefined}} and return.

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -126,7 +126,7 @@ A {{Document}} is in a <dfn>first-party-site context</dfn> if it is the [=active
 
 A {{Document}} is in a <dfn>third party context</dfn> if it is not in a [=first-party-site context=].
 
-Let <dfn export abstract-op>whether the user agent explicitly allows unpartitioned cookie access</dfn> be an algorithm that, given a [=tuple=] |tuple| consisting of two [=sites=], runs the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
+To <dfn>determine whether the user agent explicitly allows unpartitioned cookie access</dfn>, given a [=tuple=] |tuple| consisting of two [=sites=], run the following steps. This algorithm returns "`none`", "`allow`" or "`disallow`".
         
     Note: A user agent's settings might explicitly allow or disallow unpartitioned cookie access through per-site allow-lists, the user changing global browser settings, or similar custom overrides.
         
@@ -166,7 +166,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from the [=top-level origin=] of |doc|'s [=relevant settings object=].
 1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |doc|'s [=Document/origin=].
 1. Run the following steps [=in parallel=]:
-    1. Let |explicitSetting| be the result of determining <a abstract-op>whether the user agent explicitly allows unpartitioned cookie access</a> with (|topLevelSite|, |embeddedSite|).
+    1. Let |explicitSetting| be the result of [=determine whether the user agent explicitly allows unpartitioned cookie access|determining whether the user agent explicitly allows unpartitioned cookie access=] with (|topLevelSite|, |embeddedSite|).
     1. [=Queue a global task=] on the [=networking task source=] given |global| to:
         1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
         1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
@@ -209,7 +209,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
             1. Else:
                 1. [=Consume user activation=] given |global|.
                 1. [=/Reject=] |p| with a "{{NotAllowedError}}" {{DOMException}}.
-    1. Let |explicitSetting| be the result of determining <a abstract-op>whether the user agent explicitly allows unpartitioned cookie access</a> with (|topLevelSite|, |embeddedSite|).
+    1. Let |explicitSetting| be the result of [=determine whether the user agent explicitly allows unpartitioned cookie access|determining whether the user agent explicitly allows unpartitioned cookie access=] with (|topLevelSite|, |embeddedSite|).
     1. If |explicitSetting| is "`disallow`":
         1. Run |process permission state| with [=permission/denied=].
         1. Abort these steps.


### PR DESCRIPTION
<!--
Thank you for contributing to The Storage Access API! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
This change tries to make rSA behavior aligns with hSA and user expectations by including a check of whether the user agent allows the `document` to access unpartitioned data based on user settings, and move early resolve cases, such as top-level case and same-site case, behind the user settings check. Specifically:
* For the cases where hSA returns true, calling rSA will not show a prompt.
* For the cases where hSA returns false, calling rSA may or may not show a prompt:
    * If user settings explicitly disallow unpartitioned data access, calling rSA will resolve with "denied" and not show a prompt.
    * If no user settings exist, calling rSA may either resolve with "granted" depending on heuristics and not show a prompt, or show a prompt when there isn't an existing grant.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1441133
   * Gecko: …
   * WebKit: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shuranhuang/storage-access/pull/186.html" title="Last updated on Oct 16, 2023, 4:06 PM UTC (8f7c1ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/186/71a6071...shuranhuang:8f7c1ea.html" title="Last updated on Oct 16, 2023, 4:06 PM UTC (8f7c1ea)">Diff</a>