### PR TITLE
Update Chrome's implementation status to "shipping"

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ for instance through invisible overlay iframes à la Clickjacking or through ifr
 - Firefox : Shipping
 - Edge : Implementing
 - Brave : Positive
-- Chrome : Implementing
+- Chrome : Shipping
 
 ## References & Acknowledgements
 


### PR DESCRIPTION
This updates Chrome's position to indicate that we are shipping our implementation. Chrome's implementation is now enabled on desktop platforms in Chrome; Android is not far behind.