### PR TITLE
Adhere to Same Origin Policy more strictly

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -193,7 +193,7 @@ To <dfn>determine the initial storage-access eligibility</dfn>, given a [=reques
     1. If |request|'s [=request/client=] is null, return "<code>[=storage access eligibility/unset=]</code>".
     1. If |request|'s [=request/client=]'s [=environment/ancestry=] is not "<code>cross-site</code>", return "<code>[=storage access eligibility/unset=]</code>"
     1. If |request|'s [=request/client=]'s [=environment/has storage access=] is false, return "<code>[=storage access eligibility/ineligible=]</code>".
-    1. If |request|'s [=url/origin=] is not [=/same site=] with |request|'s [=request/url=]'s [=url/origin=], return "<code>[=storage access eligibility/ineligible=]</code>".
+    1. If |request|'s [=url/origin=] is not [=/same origin=] with |request|'s [=request/url=]'s [=url/origin=], return "<code>[=storage access eligibility/ineligible=]</code>".
     1. Let |allowed| be the result of running [$Should request be allowed to use feature?$] given "<a permission><code>storage-access</code></a>" and |request|.
     1. If |allowed| is false, return "<code>[=storage access eligibility/ineligible=]</code>".
     1. Return "<code>[=storage access eligibility/eligible=]</code>".
@@ -343,7 +343,7 @@ Insert a new step after step 14 of [=fetch=]:
 Insert a new step after step 17 of [=HTTP-redirect fetch=]:
 
 <div algorithm="modified HTTP-redirect fetch">
-    18. If |request|'s [=request/eligible for storage-access=] is not "<code>[=storage access eligibility/unset=]</code>" and <var ignore>locationURL</var>'s [=url/origin=] is not [=/same site=] with |request|'s [=request/current URL=]'s [=url/origin=], set |request|'s [=request/eligible for storage-access=] to "<code>[=storage access eligibility/ineligible=]</code>".
+    18. If |request|'s [=request/eligible for storage-access=] is not "<code>[=storage access eligibility/unset=]</code>" and <var ignore>locationURL</var>'s [=url/origin=] is not [=/same origin=] with |request|'s [=request/current URL=]'s [=url/origin=], set |request|'s [=request/eligible for storage-access=] to "<code>[=storage access eligibility/ineligible=]</code>".
 </div>
 
 <h3 id="storage">Changes to various client-side storage mechanisms</h3>


### PR DESCRIPTION
This is meant to address the ambiguities pointed out in #210 by defining Storage Access's integration with Fetch more rigorously. This PR codifies the behavior I'd like to Storage Access implementations to align on (namely stricter adherence to the Same Origin Policy).

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * Webkit
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://crrev.com/c/6241903 ([wpt.fyi](https://wpt.fyi/results/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.tentative.window.html))
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/379030052
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1960071
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=291440


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/storage-access/pull/213.html" title="Last updated on Apr 11, 2025, 7:27 PM UTC (1938b57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/213/8b80aa2...cfredric:1938b57.html" title="Last updated on Apr 11, 2025, 7:27 PM UTC (1938b57)">Diff</a>