### PR TITLE
Remove upstreamed environment's has storage access

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -171,9 +171,6 @@ To <dfn>determine the effective FedCM connection status</dfn> given a [=/origin=
 
 <h3 id="ua-state">Changes to user agent state related to storage access</h3>
 
-Modify the definition of [=environment=] in the following manner:
-1. Add a new member called <dfn for="environment">has storage access</dfn> of type [=boolean=].
-
 Modify the definition of [=source snapshot params=] in the following manner:
 1. Add a new member called <dfn for="source snapshot params">has storage access</dfn> of type [=boolean=].
 1. Add a new member called <dfn for="source snapshot params">environment id</dfn> of type opaque [=string=].


### PR DESCRIPTION
- [ ] At least two implementers are interested (and none opposed):
   * Gecko
   * Webkit
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * n/a
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * n/a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bvandersloot-mozilla/storage-access/pull/217.html" title="Last updated on May 22, 2025, 2:28 PM UTC (cbb843b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/217/b569d1e...bvandersloot-mozilla:cbb843b.html" title="Last updated on May 22, 2025, 2:28 PM UTC (cbb843b)">Diff</a>