### PR TITLE
Use `origin` and `embedded origin` in permission key generation algorithm

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -399,7 +399,7 @@ The Storage Access API defines a [=powerful feature=] identified by the [=powerf
   </dd>
   <dt>[=powerful feature/permission key generation algorithm=]</dt>
   <dd>
-    To generate a new [=permission key=] for the "<a permission><code>storage-access</code></a>" feature, given an [=/origin=] |origin| and [=/origin=] |embeddedOrigin|, run the following steps:
+    To generate a new [=permission key=] for the "<a permission><code>storage-access</code></a>" feature, given an [=/origin=] |origin| and [=/origin=] |embeddedOrigin|:
 
     1. Let |topLevelSite| be the result of [=obtain a site|obtaining a site=] from |origin|.
     1. Let |embeddedSite| be the result of [=obtain a site|obtaining a site=] from |embeddedOrigin|.


### PR DESCRIPTION
To align with the change to the [permission key generation algorithm](https://w3c.github.io/permissions/#dfn-permission-key-generation-algorithm) that was modified in https://github.com/w3c/permissions/pull/468 (revised: https://github.com/w3c/permissions/pull/469) to the Permissions spec, storage access api's algorithm should be updated to accept an origin and embedded origin, rather than an ESO.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jalonthomas/storage-access/pull/233.html" title="Last updated on Oct 17, 2025, 2:26 PM UTC (0243906)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/233/b569d1e...jalonthomas:0243906.html" title="Last updated on Oct 17, 2025, 2:26 PM UTC (0243906)">Diff</a>