### PR TITLE
Add missing same-site check in `document.hasStorageAccess`

### DIFF
--- a/storage-access.bs
+++ b/storage-access.bs
@@ -230,16 +230,16 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
     1. Let |explicitSetting| be the result of [=determine whether the user agent explicitly allows unpartitioned cookie access|determining whether the user agent explicitly allows unpartitioned cookie access=] with (|topLevelSite|, |embeddedSite|).
     1. Let |permissionState| be the result of [=getting the current permission state=] given "<a permission><code>storage-access</code></a>" and |global|.
     1. [=Queue a global task=] on the [=networking task source=] given |global| to:
-        1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false.
-        1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true.
+        1. If |explicitSetting| is "`disallow`", [=/resolve=] |p| with false and abort these steps.
+        1. If |explicitSetting| is "`allow`", [=/resolve=] |p| with true and abort these steps.
         1. [=Assert=]: |explicitSetting| is "`none`".
-        1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true.
-        1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true.
+        1. If |browsingContext| is a [=top-level browsing context=], [=/resolve=] |p| with true and abort these steps.
+        1. If |browsingContext| is same authority with |browsingContext|'s [=top-level browsing context=]'s [=active document=], [=/resolve=] |p| with true and abort these steps.
 
             ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=/same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=/same site=] check with the top-level document.
             
-        1. If |embeddedSite| is [=site/same site=] with |topLevelSite|, [=/resolve=] |p| with |global|'s [=environment/has storage access=].
-        1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
+        1. If |embeddedSite| is [=site/same site=] with |topLevelSite|, [=/resolve=] |p| with |global|'s [=environment/has storage access=] and abort these steps.
+        1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=] and abort these steps.
                 
             Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
 

--- a/storage-access.bs
+++ b/storage-access.bs
@@ -212,6 +212,7 @@ partial interface Document {
 };
 </pre>
 
+<div algorithm>
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>hasStorageAccess()</code></dfn> method must run these steps:
 
 <!-- https://developer.mozilla.org/en-US/docs/Web/API/Document/hasStorageAccess -->
@@ -237,6 +238,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
 
             ISSUE: "same authority" here is a placeholder for a future concept that allows user agents to perform [=/same site=] checks while adhering to additional security aspects such as the presence of a cross-site parent document, see [whatwg/storage#142](https://github.com/whatwg/storage/issues/142#issuecomment-1122147159). In practice, this might involve comparing the [=site for cookies=] or performing a [=/same site=] check with the top-level document.
             
+        1. If |embeddedSite| is [=site/same site=] with |topLevelSite|, [=/resolve=] |p| with |global|'s [=environment/has storage access=].
         1. If |permissionState| is [=permission/granted=], [=/resolve=] |p| with |global|'s [=environment/has storage access=].
                 
             Note: The global storage access permission state takes precedence over the local [=environment/has storage access=] flag here, in order to immediately reflect a possible user choice to revoke the permission in their settings.
@@ -244,6 +246,9 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>ha
         1. [=/Resolve=] |p| with false.
 1. Return |p|.
 
+</div>
+
+<div algorithm>
 When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>requestStorageAccess()</code></dfn> method must run these steps:
 
 <!-- https://developer.mozilla.org/en-US/docs/Web/API/Document/requestStorageAccess -->
@@ -311,6 +316,7 @@ When invoked on {{Document}} |doc|, the <dfn export method for=Document><code>re
 1. Return |p|.
 
 NOTE: The intent of this algorithm is to always require user activation before a storage-access permission will be set. Though it is within the means of user agents to set storage-access permissions based on custom heuristics without prior user activation, this specification strongly discourages such behavior, as it could lead to interoperability issues.
+</div>
 
 <h3 id="navigation">Changes to navigation</h3>
 


### PR DESCRIPTION
This adds the missing check for an `A(B(A))` embedding case in `document.hasStorageAccess()`, to match the corresponding check in `document.requestStorageAccess()` (see step 16.7). The effect is that for ABA embeds, after `document.requestStorageAccess()` is called and resolves, invocations of `document.hasStorageAccess()` resolve to `true`.

Fixes #234.

- [X] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit (https://github.com/privacycg/storage-access/issues/171#issuecomment-1547546652)
   * Gecko (https://github.com/privacycg/storage-access/issues/171#issuecomment-1550243957)
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://crrev.com/c/7795672
   * Note: the case where `document.hasStorageAccess()` should return false in the ABA embed (i.e. when `document.requestStorageAccess()` has not been called) is already tested at https://github.com/web-platform-tests/wpt/blob/af3b02cb13c11ad6299bdda16813bd8e5048aa60/storage-access-api/hasStorageAccess.sub.https.window.js#L26.
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2035026
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=313328

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/storage-access/pull/244.html" title="Last updated on Apr 29, 2026, 12:19 AM UTC (9191ba9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/storage-access/244/03af52d...cfredric:9191ba9.html" title="Last updated on Apr 29, 2026, 12:19 AM UTC (9191ba9)">Diff</a>